### PR TITLE
Remove -s shorthand, use --server instead

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -63,7 +63,7 @@ def parse_input():
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-q', '--question', type=str,
                         help="focus on a specific question")
-    parser.add_argument('-s', '--server', type=str,
+    parser.add_argument('--server', type=str,
                         default='ok-server.appspot.com',
                         help="server address")
     parser.add_argument('-t', '--tests', metavar='A', default='tests', type=str,


### PR DESCRIPTION
Fixes #315 . Command line typos like `-submit` were being interpreted by argparse as `-s ubmit` (the `server` flag). Now, the server can be specified only with `--server`.