### PR TITLE
Send course id back to client

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1044,7 +1044,8 @@ class SubmissionAPI(APIResource):
                                                messages, submit, submitter)
         return (201, 'success', {
             'key': submission.key.id(),
-            'course': valid_assignment.course.id()
+            'course': valid_assignment.course.id(),
+            'email': user.email[0]
         })
 
     def post(self, user, data):

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1043,7 +1043,8 @@ class SubmissionAPI(APIResource):
         submission = self.db.create_submission(user, valid_assignment,
                                                messages, submit, submitter)
         return (201, 'success', {
-            'key': submission.key.id()
+            'key': submission.key.id(),
+            'course': valid_assignment.course.id()
         })
 
     def post(self, user, data):


### PR DESCRIPTION
Send the courseId back to the client.  

I've tested it and it seems to work and doesn't seem to crash clients that don't accept the courseId. This isn't deployed yet. 

@Some3141 