### PR TITLE
Add Sudo Mode for Admins

### DIFF
--- a/server/app/templates/error.html
+++ b/server/app/templates/error.html
@@ -26,32 +26,6 @@
           <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
           <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
         <![endif]-->
-        <script src="/static/vendor/angular/angular.js"></script>
-        <script src="/static/vendor/highlightjs/highlight.pack.js"></script>
-        <script src="/static/vendor/angular-resource/angular-resource.js"></script>
-        <script src="/static/vendor/underscore/underscore.js"></script>
-        <script src="/static/vendor/angular-ui-router/release/angular-ui-router.js"></script>
-        <script src="/static/vendor/angular-loading-bar/build/loading-bar.min.js"></script>
-        <script src="/static/vendor/angular-animate/angular-animate.js"></script>
-        <script src="/static/vendor/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
-        <script src="/static/vendor/moment/moment.js"></script>
-        <script src="/static/vendor/angular-moment/angular-moment.js"></script>
-        <script src="/static/vendor/showdown/compressed/showdown.js"></script>
-
-        <!--<script src="/static/js/main.js"></script>-->
-        <!--<script src="/static/js/resources.js"></script>-->
-        <!--<script src="/static/js/controllers.js"></script>-->
-
-        <script src="/static/js/dashboard.js"></script>
-
-        <script src="/static/js/common/main.js"></script>
-        <script src="/static/js/common/services.js"></script>
-        <script src="/static/js/common/controllers.js"></script>
-
-        <script src="/static/js/dashboard/controllers.js"></script>
-
-        <script src="/static/admin/js/ok/app.js"></script>
-
 
 
     </head>
@@ -70,14 +44,14 @@
                         <!-- User Account: style can be found in dropdown.less -->
                           <li class="user">
                               <a href="/">Homepage</a>
-                          </li> 
+                          </li>
                     </ul>
                 </div>
             </nav>
         </header>
-      
+
         {% if admin %}
-          <!-- Todo --> 
+          <!-- Todo -->
         {% endif %}
 
         <aside >

--- a/server/app/templates/landing.html
+++ b/server/app/templates/landing.html
@@ -29,7 +29,7 @@
         <h2 class="subtitle">Run tests, track progress, and assist in debugging</h2>
         <span class="break">
         {% if user %}
-              <a href='/ok' class="button">Student Dashboard</a></span>
+              <a href='/login' class="button">Student Dashboard</a></span>
         {% else %}
               <a href={{users_link}} class="button">Student Login</a></span>
         {% endif %}

--- a/server/app/templates/sudo.html
+++ b/server/app/templates/sudo.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html class="no-js" ng-app="student">
+  <head>
+    <meta charset="UTF-8">
+    <title>Ok SUDO</title>
+
+    <link href="/static/student/styles/all.css" rel="stylesheet">
+    <link rel="stylesheet" href="/static/student/styles/zenburn.css">
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.11.2/themes/smoothness/jquery-ui.css">
+    <link href="/static/vendor/angular-loading-bar/build/loading-bar.css" rel="stylesheet"></link>
+
+    <link href="/static/vendor/sweetalert/lib/sweet-alert.css" rel="stylesheet"></link>
+
+    <script src="/static/vendor/jquery/dist/jquery.min.js"></script>
+
+    <script src="//code.jquery.com/ui/1.11.2/jquery-ui.js"></script>
+    <script src="//cdn.ravenjs.com/1.1.16/angular,jquery,native/raven.min.js" ></script>
+
+    <script src="/static/student/scripts/all.js"></script>
+    <script src="/static/student/scripts/highlight.pack.js"></script>
+
+    <script src="/static/vendor/angular/angular.js"></script>
+    <script src="/static/vendor/highlightjs/highlight.pack.js"></script>
+
+    <link href="/static/vendor/angular-tablesort/tablesort.css" rel="stylesheet"></link>
+
+    <script src="/static/vendor/angular-resource/angular-resource.js"></script>
+    <script src="/static/vendor/underscore/underscore.js"></script>
+    <script src="/static/vendor/angular-ui-router/release/angular-ui-router.js"></script>
+    <script src="/static/vendor/angular-loading-bar/build/loading-bar.min.js"></script>
+    <script src="/static/vendor/angular-animate/angular-animate.js"></script>
+    <script src="/static/vendor/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
+    <script src="/static/vendor/moment/moment.js"></script>
+    <script src="/static/js/other/moment-timezone-with-data.js"></script>
+    <script src="/static/vendor/angular-moment/angular-moment.js"></script>
+    <script src="/static/vendor/showdown/compressed/showdown.js"></script>
+    <script src="/static/vendor/sweetalert/lib/sweet-alert.min.js"></script>
+    <script src="/static/vendor/angular-tablesort/js/angular-tablesort.js"></script>
+    <script src="/static/vendor/angular-ui-sortable/sortable.js"></script>
+
+    <script src="/static/js/student.js"></script>
+    <script src="/static/js/common/main.js"></script>
+    <script src="/static/js/common/services.js"></script>
+    <script src="/static/js/common/controllers.js"></script>
+    <script src="/static/js/student/controllers.js"></script>
+    <script src="/static/admin/js/ok/app.js"></script>
+
+    <script>
+    Raven.config('https://edc8538d3d5f47fcb1b14c33d9ae7d8b@app.getsentry.com/36686', {
+        whitelistUrls: ['https://ok-server.appspot.com', 'ok-server.appspot.com', 'localhost']
+    }).install();
+    </script>
+
+  </head>
+  <body class="course">
+    <div class="main">
+      <div class="shadow"></div>
+      <div class="content">
+
+        <header>
+          <a ui-sref="dashboard" class="logo">
+            <img src="/static/student/images/logo-light.png">
+            <h1>Okpy</h1>
+          </a>
+          {% if sudo %}
+            <script>
+              window.sudo = "{{sudo.admin}}";
+            </script>
+            <div class="alert active red">
+              <p class="alert-info"><b>SUDO:</b> You are viewing as {{ sudo.su }}. Your actions are being logged. </p>
+              <div class="close"><a href={{users_link}}><span class="icon-x">+</span></a> </div>
+            </div>
+
+          {% endif %}
+
+        </header>
+
+        <nav class="tools">
+          <ul>
+          {% if sudo %}
+              <li><a href={{users_link}}>{{users_title}}</a></li>
+          {% endif %}
+
+          {% if user %}
+
+            <li>
+              <a class="show-menu">
+                Menu
+                <span class="stripes">
+                  <span class="stripe"></span>
+                  <span class="stripe"></span>
+                  <span class="stripe"></span>
+                </span>
+              </a>
+          {% else %}
+            <li>
+              <a href={{users_link}}>{{users_title}}</a>
+            </li>
+          {% endif %}
+
+            </li>
+          </ul>
+        </nav>
+
+        <span class="menu-cover"></span>
+        <nav class="menu">
+          <ul>
+            <div class="close light close-menu"><span class="icon-x">+</span></div>
+            {% if user %}
+                <li><a href>{{user.email}}</a></li>
+            {% endif %}
+            <li><a href="http://cs61a.org">CS61A</a></li>
+            <li><a href={{users_link}}>{{users_title}}</a></li>
+          </ul>
+        </nav>
+        {% if user %}
+            <script>
+              window.user = "{{user.email}}";
+              window.userId = "{{user.id}}";
+              window.reloginLink = "{{relogin_link}}";
+            </script>
+            <div ui-view></div>
+          {% else %}
+                <span class="firstLogin"><a href={{users_link}} class="button">Login</a></span>
+          {% endif %}
+
+    </div>
+
+
+    <div class="loader hide">
+      <div class="center">
+        <div class="circle">
+          <span class="mask">
+            <span class="half"></span>
+          </span>
+          <span class="mask other">
+            <span class="half"></span>
+          </span>
+        </div>
+        <p>k</p>
+      </div>
+    </div>
+
+  </body>
+  <link href='//fonts.googleapis.com/css?family=Raleway:100|Open+Sans:300,700' rel='stylesheet' type='text/css'>
+</html>

--- a/server/app/urls.py
+++ b/server/app/urls.py
@@ -65,11 +65,7 @@ def landing():
 def sudo(su_email):
     user = users.get_current_user()
     params = {}
-    if user is None:
-        params['users_link'] = force_account_chooser(
-            users.create_login_url('/'))
-        params['users_title'] = "Sign In"
-    else:
+    if user is not None:
         logging.info("Staff Login Attempt from %s, Attempting to login as %s", user.email(), su_email)
         userobj = models.User.lookup(user.email())
         if userobj.is_admin:
@@ -86,6 +82,7 @@ def sudo(su_email):
           logging.error("Sudo %s to %s failure", user.email(), su_email)
           error = {'code': 403, 'description': "Insufficient permission"}
           return page_not_found(error)
+    return redirect(url_for('login'))
 
 @app.route("/login")
 def login():
@@ -138,7 +135,7 @@ def admin():
             return render_template("admin.html", **params)
         else:
             logging.info("Staff Login Failure from %s", user.email())
-            error = {'code': 403, 'description': "Insufficient permission"}
+            error = {'code': 404, 'description': "Insufficient permission"}
             return page_not_found(error)
 
 ## Error handlers

--- a/server/app/urls.py
+++ b/server/app/urls.py
@@ -69,15 +69,19 @@ def sudo(su_email):
         logging.info("Staff Login Attempt from %s, Attempting to login as %s", user.email(), su_email)
         userobj = models.User.lookup(user.email())
         if userobj.is_admin:
-          logging.info("Sudo %s to %s success", user.email(), su_email)
+          logging.info("Sudo %s to %s granted", user.email(), su_email)
           substitute = models.User.lookup(su_email)
-          params["user"] = {'id': substitute.key, 'email' : substitute.email[0]}
-          params["sudo"] = {'su': substitute.email[0], 'admin': user.email()}
-          params['users_link'] = '/'
-          params['users_title'] = "Exit Sudo Mode"
-          params['relogin_link'] = '/'
-          params['DEBUG'] = app.config['DEBUG']
-          return render_template("sudo.html", **params)
+          if substitute
+            params["user"] = {'id': substitute.key, 'email' : substitute.email[0]}
+            params["sudo"] = {'su': substitute.email[0], 'admin': user.email()}
+            params['users_link'] = '/'
+            params['users_title'] = "Exit Sudo Mode"
+            params['relogin_link'] = '/'
+            params['DEBUG'] = app.config['DEBUG']
+            return render_template("sudo.html", **params)
+          else:
+            error = {'code': 404, 'description': "User not found"}
+            return page_not_found(error)
         else:
           logging.error("Sudo %s to %s failure", user.email(), su_email)
           error = {'code': 403, 'description': "Insufficient permission"}

--- a/server/app/urls.py
+++ b/server/app/urls.py
@@ -42,7 +42,6 @@ def home():
     params['DEBUG'] = app.config['DEBUG']
     return render_template("student.html", **params)
 
-
 @app.route("/landing")
 def landing():
     user = users.get_current_user()
@@ -61,6 +60,32 @@ def landing():
     params['DEBUG'] = app.config['DEBUG']
     return render_template("landing.html", **params)
 
+
+@app.route("/sudo/su/<su_email>")
+def sudo(su_email):
+    user = users.get_current_user()
+    params = {}
+    if user is None:
+        params['users_link'] = force_account_chooser(
+            users.create_login_url('/'))
+        params['users_title'] = "Sign In"
+    else:
+        logging.info("Staff Login Attempt from %s, Attempting to login as %s", user.email(), su_email)
+        userobj = models.User.lookup(user.email())
+        if userobj.is_admin:
+          logging.info("Sudo %s to %s success", user.email(), su_email)
+          substitute = models.User.lookup(su_email)
+          params["user"] = {'id': substitute.key, 'email' : substitute.email[0]}
+          params["sudo"] = {'su': substitute.email[0], 'admin': user.email()}
+          params['users_link'] = '/'
+          params['users_title'] = "Exit Sudo Mode"
+          params['relogin_link'] = '/'
+          params['DEBUG'] = app.config['DEBUG']
+          return render_template("sudo.html", **params)
+        else:
+          logging.error("Sudo %s to %s failure", user.email(), su_email)
+          error = {'code': 403, 'description': "Insufficient permission"}
+          return page_not_found(error)
 
 @app.route("/login")
 def login():
@@ -113,7 +138,8 @@ def admin():
             return render_template("admin.html", **params)
         else:
             logging.info("Staff Login Failure from %s", user.email())
-    return redirect(url_for('dashboard'))
+            error = {'code': 403, 'description': "Insufficient permission"}
+            return page_not_found(error)
 
 ## Error handlers
 # Handle 404 errors

--- a/server/app/urls.py
+++ b/server/app/urls.py
@@ -71,7 +71,7 @@ def sudo(su_email):
         if userobj.is_admin:
           logging.info("Sudo %s to %s granted", user.email(), su_email)
           substitute = models.User.lookup(su_email)
-          if substitute
+          if substitute:
             params["user"] = {'id': substitute.key, 'email' : substitute.email[0]}
             params["sudo"] = {'su': substitute.email[0], 'admin': user.email()}
             params['users_link'] = '/'

--- a/server/static/js/common/services.js
+++ b/server/static/js/common/services.js
@@ -1,6 +1,6 @@
 app.factory('User', ['$resource',
     function($resource) {
-      return $resource('api/v1/user/:id', {
+      return $resource('/api/v1/user/:id', {
         format: "json",
         id: window.user,
       }, {
@@ -16,7 +16,7 @@ app.factory('User', ['$resource',
           }
         },
         invitations: {
-          url: 'api/v1/user/:id/invitations',
+          url: '/api/v1/user/:id/invitations',
           isArray: true,
           transformResponse: function(data) {
             return JSON.parse(data).data;
@@ -24,7 +24,7 @@ app.factory('User', ['$resource',
         },
         finalsub: {
           method: "GET",
-          url: 'api/v1/user/:id/final_submission',
+          url: '/api/v1/user/:id/final_submission',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
@@ -32,7 +32,7 @@ app.factory('User', ['$resource',
         getBackups: {
           method: "GET",
           isArray: true,
-          url: 'api/v1/user/:id/get_backups',
+          url: '/api/v1/user/:id/get_backups',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
@@ -40,7 +40,7 @@ app.factory('User', ['$resource',
         getSubmissions: {
           method: "GET",
           isArray: true,
-          url: 'api/v1/user/:id/get_submissions',
+          url: '/api/v1/user/:id/get_submissions',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
@@ -51,7 +51,7 @@ app.factory('User', ['$resource',
 
 app.factory('Submission', ['$resource',
     function($resource) {
-      return $resource('api/v1/submission/:id', {
+      return $resource('/api/v1/submission/:id', {
         format: "json",
         id: "@id",
       }, {
@@ -64,42 +64,42 @@ app.factory('Submission', ['$resource',
           cache: true
         },
         diff: {
-          url: 'api/v1/submission/:id/diff',
+          url: '/api/v1/submission/:id/diff',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         addScore: {
           method: "POST",
-          url: 'api/v1/submission/:id/score',
+          url: '/api/v1/submission/:id/score',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         addComment: {
           method: "POST",
-          url: 'api/v1/submission/:id/add_comment',
+          url: '/api/v1/submission/:id/add_comment',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         deleteComment: {
           method: "POST",
-          url: 'api/v1/submission/:id/delete_comment',
+          url: '/api/v1/submission/:id/delete_comment',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         addTag: {
           method: "PUT",
-          url: 'api/v1/submission/:id/add_tag',
+          url: '/api/v1/submission/:id/add_tag',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         removeTag: {
           method: "PUT",
-          url: 'api/v1/submission/:id/remove_tag',
+          url: '/api/v1/submission/:id/remove_tag',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
@@ -110,7 +110,7 @@ app.factory('Submission', ['$resource',
 
 app.factory('Assignment', ['$resource',
     function($resource) {
-      return $resource('api/v1/assignment/:id', {
+      return $resource('/api/v1/assignment/:id', {
         format: "json",
         id: "@id"
       }, {
@@ -127,14 +127,14 @@ app.factory('Assignment', ['$resource',
           }
         },
         group: {
-          url: 'api/v1/assignment/:id/group',
+          url: '/api/v1/assignment/:id/group',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         invite: {
           method: "POST",
-          url: 'api/v1/assignment/:id/invite',
+          url: '/api/v1/assignment/:id/invite',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
@@ -145,33 +145,33 @@ app.factory('Assignment', ['$resource',
 
 app.factory('Group', ['$resource',
     function($resource) {
-      return $resource('api/v1/group/:id', {
+      return $resource('/api/v1/group/:id', {
         format: "json",
           id: "@id"
       }, {
         addMember: {
-          url: 'api/v1/group/:id/add_member',
+          url: '/api/v1/group/:id/add_member',
           method: 'PUT',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         removeMember: {
-          url: 'api/v1/group/:id/remove_member',
+          url: '/api/v1/group/:id/remove_member',
           method: 'PUT',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         acceptInvitation: {
-          url: 'api/v1/group/:id/accept',
+          url: '/api/v1/group/:id/accept',
           method: 'PUT',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         rejectInvitation: {
-          url: 'api/v1/group/:id/decline',
+          url: '/api/v1/group/:id/decline',
           method: 'PUT',
           transformResponse: function(data) {
             return JSON.parse(data).data;
@@ -183,7 +183,7 @@ app.factory('Group', ['$resource',
 
 app.factory('Course', ['$resource',
     function($resource) {
-      return $resource('api/v1/course/:id', {
+      return $resource('/api/v1/course/:id', {
         format: "json",
       }, {
         query: {
@@ -201,19 +201,19 @@ app.factory('Course', ['$resource',
         },
         staff: {
           isArray: true,
-          url: 'api/v1/course/:id/get_staff',
+          url: '/api/v1/course/:id/get_staff',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         add_member: {
-          url: 'api/v1/course/:id/add_staff',
+          url: '/api/v1/course/:id/add_staff',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
         },
         remove_member: {
-          url: 'api/v1/course/:id/remove_staff',
+          url: '/api/v1/course/:id/remove_staff',
           transformResponse: function(data) {
             return JSON.parse(data).data;
           }
@@ -224,7 +224,7 @@ app.factory('Course', ['$resource',
 
 app.factory('Version', ['$resource',
     function($resource) {
-      return $resource('api/v1/version/:id', {
+      return $resource('/api/v1/version/:id', {
         format: "json",
       }, {
         query: {
@@ -241,7 +241,7 @@ app.factory('Version', ['$resource',
         },
         update: {
           method: "PUT",
-          url: "api/v1/version/:id/new",
+          url: "/api/v1/version/:id/new",
           params: {}
         }
       });
@@ -250,7 +250,7 @@ app.factory('Version', ['$resource',
 
 app.factory('Queue', ['$resource',
     function($resource) {
-      return $resource('api/v1/queue/:id', {
+      return $resource('/api/v1/queue/:id', {
         format: "json",
         id: "@id",
       }, {

--- a/server/tests/integration/test_sudo.py
+++ b/server/tests/integration/test_sudo.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+Tests for the permissions system
+"""
+
+import os
+os.environ['FLASK_CONF'] = 'TEST'
+import datetime
+import urllib
+import flask
+
+from test_base import APIBaseTestCase, unittest #pylint: disable=relative-import
+
+from app import models, utils
+
+from google.appengine.ext import ndb
+
+from app import auth
+from app.authenticator import Authenticator, AuthenticationException
+
+class SudoUnitTest(APIBaseTestCase):
+    def get_accounts(self):
+        """
+        Returns the accounts you want to exist in your system.
+        """
+        return {
+            "student0": models.User(
+                email=["dummy@student.com"]
+            ),
+            "student1": models.User(
+                email=["other@student.com"]
+            ),
+            "staff": models.User(
+                email=["dummy@staff.com"]
+            ),
+            "admin": models.User(
+                email=["dummy@admin.com"],
+                is_admin=True
+            ),
+            "dummy_admin": models.User(
+                email=["dummy3@admin.com"],
+                is_admin=True
+            )
+        }
+
+    def get(self, url, *args, **kwds):
+        """
+        Makes a get request.
+        """
+        url = url
+        self.response = self.client.get(url, *args)
+
+    def assertStatusCode(self, code): #pylint: disable=invalid-name
+        self.assertEqual(self.response.status_code, code, self.response.headers)
+
+    def setUp(self):
+        super(SudoUnitTest, self).setUp()
+        self.accounts = self.get_accounts()
+        for user in self.accounts.values():
+            user.put()
+        self.user = None
+
+    # User should be redirected to login.
+    def testNoLogin(self):
+        self.get('/sudo/su/dummy@student.com')
+        self.assertStatusCode(302)
+
+    def testLoginToSudo(self):
+        self.login('admin')
+        self.get('/sudo/su/dummy@student.com')
+        self.assertStatusCode(200)
+        self.logout()
+
+    def testStudentAttemptToSudo(self):
+        self.login('student1')
+        self.get('/sudo/su/dummy@student.com')
+        self.assertStatusCode(404)
+
+    def testNonExistantStudent(self):
+        self.login('admin')
+        self.get('/sudo/su/nonexistant@student.com')
+        self.assertStatusCode(404)
+
+    def testCheckStudent2(self):
+        self.login('staff')
+        self.get('/sudo/su/other@student.com')
+        self.assertStatusCode(404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An admin can su into another users account. This should be useful for looking at ok issues or viewing code (though it's intended for site admins - not staff because there are no course level restrictions). 

The way to access it is to login as a user and then go to `server-url.appspot.com/sudo/su/student@email.com`
It logs any attempts to sudo and displays a warning to admins. 

![ok sudo 2015-01-25 23-11-13](https://cloud.githubusercontent.com/assets/882381/5896303/88382d40-a4e7-11e4-9454-cfdaec9260f0.png)


I think this is a useful feature for admins and it should work with no further changes. 