### PR TITLE
Comment out seeding, uncoment in app.__init__ for local testing

### DIFF
--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -21,9 +21,12 @@ DEBUG = (os.environ['SERVER_SOFTWARE'].startswith('Dev')
          if 'SERVER_SOFTWARE' in os.environ
          else True)
 
+
 TESTING = os.environ["FLASK_CONF"] == "TEST" if "FLASK_CONF" in os.environ else False
-if DEBUG and not TESTING and not is_seeded():
-    seed()
+
+# Uncomment for local webapp testing
+# if DEBUG and not TESTING and not is_seeded():
+#     seed()
 
 if DEBUG:
     app.config.from_object('app.settings.Debug')

--- a/server/app/templates/student.html
+++ b/server/app/templates/student.html
@@ -66,6 +66,7 @@
           <ul>
           {% if user %}
             <li><a href="/static/student/tour.html"><span class="icon-question">?</span></a></li>
+            <li> {{user.email}}  </li>
 
             <li>
               <a class="show-menu">


### PR DESCRIPTION
Completely remove the seed from running on init. 

Workflow change: To seed locally, uncomment the three lines in `app.__init__` 