### PR TITLE
Submission endpoint accepts revisions

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1107,8 +1107,9 @@ class SubmissionAPI(APIResource):
         due = valid_assignment.due_date
         late_flag = valid_assignment.lock_date and \
                     datetime.datetime.now() >= valid_assignment.lock_date
+        revision = valid_assignment.revision
 
-        if submit and late_flag:
+        if submit and late_flag and not revision:
             # Late submission. Do not allow them to submit
             logging.info('Rejecting Late Submission', submitter)
             return (403, 'late', {

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1109,12 +1109,22 @@ class SubmissionAPI(APIResource):
                     datetime.datetime.now() >= valid_assignment.lock_date
         revision = valid_assignment.revision
 
-        if submit and late_flag and not revision:
-            # Late submission. Do not allow them to submit
-            logging.info('Rejecting Late Submission', submitter)
-            return (403, 'late', {
-                'late': True,
-                })
+        if submit and late_flag:
+            if revision:
+              # In the revision period. Ensure that user has a previously graded submission.
+              fs = user.get_final_submission(assignment)
+              if fs is None or fs.submission.score is None:
+                return (403, 'late', {
+                  'late': True,
+                  'message': "No Previous Submission",
+                  })
+            else:
+              # Late submission. Do not allow them to submit
+              logging.info('Rejecting Late Submission', submitter)
+              return (403, 'late', {
+                  'late': True,
+                  })
+
 
         models.Participant.add_role(user, valid_assignment.course, STUDENT_ROLE)
         submission = self.db.create_submission(user, valid_assignment,

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1114,6 +1114,7 @@ class SubmissionAPI(APIResource):
                 # In the revision period. Ensure that user has a previously graded submission.
                 fs = user.get_final_submission(valid_assignment)
                 if fs is None or fs.submission.get().score == []:
+                    logging.info('Rejecting Revision without graded FS', submitter)
                     return (403, 'Previous submission was not graded', {
                       'late': True,
                       })

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1111,19 +1111,18 @@ class SubmissionAPI(APIResource):
 
         if submit and late_flag:
             if revision:
-              # In the revision period. Ensure that user has a previously graded submission.
-              fs = user.get_final_submission(assignment)
-              if fs is None or fs.submission.score is None:
-                return (403, 'late', {
-                  'late': True,
-                  'message': "No Previous Submission",
-                  })
+                # In the revision period. Ensure that user has a previously graded submission.
+                fs = user.get_final_submission(valid_assignment)
+                if fs is None or fs.submission.get().score == []:
+                    return (403, 'Previous submission was not graded', {
+                      'late': True,
+                      })
             else:
-              # Late submission. Do not allow them to submit
-              logging.info('Rejecting Late Submission', submitter)
-              return (403, 'late', {
-                  'late': True,
-                  })
+                # Late submission. Do not allow them to submit
+                logging.info('Rejecting Late Submission', submitter)
+                return (403, 'late', {
+                    'late': True,
+                    })
 
 
         models.Participant.add_role(user, valid_assignment.course, STUDENT_ROLE)

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -685,8 +685,8 @@ class Submission(Base):
                 # Follow resubmssion procedure
                 final.revision = self.key
             else:
-              final.submitter = self.submitter
-              final.submission = self.key
+                final.submitter = self.submitter
+                final.submission = self.key
         else:
             group = self.submitter.get().get_group(self.assignment)
             final = FinalSubmission(

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -411,7 +411,7 @@ class Assignment(Base):
     lock_date = ndb.DateTimeProperty() # no submissions after this date
     active = ndb.ComputedProperty(
         lambda a: a.due_date and datetime.datetime.now() <= a.due_date)
-    resubmission = ndb.BooleanProperty(default=False)
+    revision = ndb.BooleanProperty(default=False)
 
     # TODO Add services requested
 
@@ -655,7 +655,7 @@ class Submission(Base):
     submitter = ndb.ComputedProperty(lambda x: x.backup.get().submitter)
     assignment = ndb.ComputedProperty(lambda x: x.backup.get().assignment)
     server_time = ndb.DateTimeProperty(auto_now_add=True)
-    is_resubmission = ndb.BooleanProperty(default=False)
+    is_revision = ndb.BooleanProperty(default=False)
 
     def get_final(self):
         assignment = self.assignment
@@ -677,9 +677,9 @@ class Submission(Base):
         final = self.get_final()
         if final:
             assignment = self.assignment.get()
-            if not assignment.active and assignment.resubmission:
+            if not assignment.active and assignment.revision:
                 # Follow resubmssion procedure
-                final.resubmission = self.key
+                final.revision = self.key
             else:
               final.submitter = self.submitter
               final.submission = self.key
@@ -1085,7 +1085,7 @@ class FinalSubmission(Base):
     assignment = ndb.KeyProperty(Assignment)
     group = ndb.KeyProperty(Group)
     submission = ndb.KeyProperty(Submission)
-    resubmission = ndb.KeyProperty(Submission)
+    revision = ndb.KeyProperty(Submission)
     queue = ndb.KeyProperty(Queue)
     submitter = ndb.KeyProperty(User) # TODO Change to ComputedProperty
     published = ndb.BooleanProperty(default=False)

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -226,20 +226,17 @@ class User(Base):
             group = self.get_group(assignment.key)
             assign_info['group'] = {'group_info': group, 'invited': group and self.key in group.invited}
             assign_info['final'] = {}
-            assign_info['final']['final_submission'] = \
-                    self.get_final_submission(assignment.key)
-            if assign_info['final']['final_submission']:
-                assign_info['final']['submission'] = \
-                        assign_info['final']['final_submission'].submission.get()
-                assign_info['final']['backup'] = \
-                        assign_info['final']['submission'].backup.get()
+            final = assign_info['final']
 
-                if assign_info['final']['final_submission'].revision:
-                    assign_info['final']['revision'] = \
-                      assign_info['final']['final_submission'].revision.get()
+            final['final_submission'] = self.get_final_submission(assignment.key)
+            if final['final_submission']:
+                final['submission'] = final['final_submission'].submission.get()
+                final['backup'] = final['submission'].backup.get()
 
-                assign_info['final']['backup'] = \
-                        assign_info['final']['submission'].backup.get()
+                if final['final_submission'].revision:
+                    final['revision'] = final['final_submission'].revision.get()
+
+                final['backup'] = final['submission'].backup.get()
 
                 # Percentage
                 final = assign_info['final']['backup']

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -684,7 +684,7 @@ class Submission(Base):
         final = self.get_final()
         if final:
             assignment = self.assignment.get()
-            if not assignment.active and assignment.revision:
+            if assignment.revision:
                 # Follow resubmssion procedure
                 final.revision = self.key
             else:

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -234,6 +234,13 @@ class User(Base):
                 assign_info['final']['backup'] = \
                         assign_info['final']['submission'].backup.get()
 
+                if assign_info['final']['final_submission'].revision:
+                    assign_info['final']['revision'] = \
+                      assign_info['final']['final_submission'].revision.get()
+
+                assign_info['final']['backup'] = \
+                        assign_info['final']['submission'].backup.get()
+
                 # Percentage
                 final = assign_info['final']['backup']
                 solved = 0

--- a/server/app/seed/__init__.py
+++ b/server/app/seed/__init__.py
@@ -33,7 +33,7 @@ def seed():
             templates['hogq.scm'] = fp.read()
 
         return models.Assignment(
-            name='proj1',
+            name='cal/CS61A/sp15/proj1',
             display_name="Hog",
             points=20,
             templates=json.dumps(templates),
@@ -153,7 +153,7 @@ def seed():
         return models.Version(
             name='ok',
             id='ok',
-            base_url='https://github.com/Cal-CS-61A-Staff/ok/releases/download',
+            base_url='https://github.com/Cal-CS-61A-Staff/ok-client/releases/download',
             versions=[current_version],
             current_version=current_version
         )
@@ -226,7 +226,7 @@ def seed():
     version.put()
     version = make_version('v1.3.2')
     version.put()
-    version = make_version('v1.3.7')
+    version = make_version('v1.3.15')
     version.put()
 
     # Put a few members on staff

--- a/server/app/templates/base.html
+++ b/server/app/templates/base.html
@@ -65,7 +65,7 @@
     <body class="skin-black">
         <!-- header logo: style can be found in header.less -->
         <header class="header">
-            <a ui-sref="dashboard" class="logo">
+            <a href="/" class="logo">
                 <!-- Add the class icon to your logo image or logo icon to add the margining -->
                 ok
             </a>

--- a/server/static/partials/student/assignment.dash.html
+++ b/server/static/partials/student/assignment.dash.html
@@ -1,6 +1,6 @@
 <div class="screen" ng-controller="AssignmentDashController">
 
-  <div class="assign " ng-class="{active: assign.assignment.active, inactive: !assign.assignment.active, small: !assign.assignment.active, large: assign.assignment.active }" id="1" ng-repeat="assign in assignments | orderBy: ['assignment.active','assignment.points']:true">
+  <div class="assign " ng-class="{'active large': assign.assignment.active || assign.assignment.revision, 'inactive small': !assign.assignment.active && !assign.assignment.revision}" id="1" ng-repeat="assign in assignments | orderBy: ['assignment.active','assignment.points']:true">
     <div class="assign-main">
       <a class="score" ng-click="showComposition(assign.final.submission.score[0],assign.final.backup.id)" ng-if="assign.final.submission && assign.final.submission.score.length > 0">
         {{ assign.final.submission.score[0].score}}
@@ -11,12 +11,14 @@
        <h2 class="assign-title"> {{ ::assign.assignment.display_name }}</h2>
       <div class="assign-deck">
         <p><img src="/static/student/images/icon-clock.png">due {{ ::assign.assignment.due_date | amCalendar }}</p>
-        <a ng-href="http://cs61a.org/" class="link light"><span class="icon-link">8</span> cs61a.org </a>
-      </div>
+        <p ng-if="assign.assignment.revision"> Composition Revisions Enabled<p>
+<!--         <a ng-href="http://cs61a.org/" class="link light"><span class="icon-link">8</span> cs61a.org </a>
+ -->      </div>
     </div>
 
     <p class="assign-status" ng-if="!assign.final.final_submission">Not submitted yet</p>
-    <p class="assign-status positive" ng-if="assign.final.final_submission">Assignment submitted!</p>
+    <p class="assign-status positive" ng-if="assign.final.final_submission && !assign.final.final_submission.revision">Assignment submitted</p>
+    <p class="assign-status positive" ng-if="assign.final.final_submission &&  assign.final.final_submission.revision"> Revision submitted </p>
 
 
     <div class="assign-more" ng-show="currAssign == assign">
@@ -64,7 +66,8 @@
             <div ng-if="assign.final.final_submission">
               <div ng-if="assign.final.final_submission.revision">
                 <h3 class="assign-subtitle">Revision</h3>
-                <a ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.final_submission.revision.id})' class="link view-submission"><p> {{ assign.final.final_submission.revision.created | amCalendar }} &raquo;</p></a> <br>
+                <a ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.final_submission.revision.id})' class="link view-submission"><p> {{ assign.final.final_submission.revision.created | amCalendar }} &raquo;</p></a>
+                <br><br>
               </div>
               <h3 class="assign-subtitle"  >Latest Submission</h3>
               <a ng-hide="assign.final.submission.score"  ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.backup.id})' class="link view-submission"><p> {{ assign.final.backup.created | amCalendar }} &raquo;</p></a> <br>

--- a/server/static/partials/student/assignment.dash.html
+++ b/server/static/partials/student/assignment.dash.html
@@ -62,6 +62,10 @@
 
           <div class="col right">
             <div ng-if="assign.final.final_submission">
+              <div ng-if="assign.final.final_submission.revision">
+                <h3 class="assign-subtitle">Revision</h3>
+                <a ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.final_submission.revision.id})' class="link view-submission"><p> {{ assign.final.final_submission.revision.created | amCalendar }} &raquo;</p></a> <br>
+              </div>
               <h3 class="assign-subtitle"  >Latest Submission</h3>
               <a ng-hide="assign.final.submission.score"  ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.backup.id})' class="link view-submission"><p> {{ assign.final.backup.created | amCalendar }} &raquo;</p></a> <br>
               <a ng-if="assign.final.submission.score"  ng-click="showComposition(assign.final.submission.score[0])" ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.backup.id})' class="link view-submission"><p> {{ assign.final.backup.created | amCalendar }} &raquo;</p></a> <br>

--- a/server/static/partials/student/assignment.dash.html
+++ b/server/static/partials/student/assignment.dash.html
@@ -66,7 +66,7 @@
             <div ng-if="assign.final.final_submission">
               <div ng-if="assign.final.final_submission.revision">
                 <h3 class="assign-subtitle">Revision</h3>
-                <a ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.final_submission.revision.id})' class="link view-submission"><p> {{ assign.final.final_submission.revision.created | amCalendar }} &raquo;</p></a>
+                <a ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.final_submission.revision.backup.id})' class="link view-submission"><p> {{ assign.final.final_submission.revision.created | amCalendar }} &raquo;</p></a>
                 <br><br>
               </div>
               <h3 class="assign-subtitle"  >Latest Submission</h3>


### PR DESCRIPTION
This PR enables support for assignment revisions - it still needs to be tested.

When an assignment is in the revision period (toggled manually) - we will allow late submissions from students who have a graded final submission. If so, we tack the new submission to a new attribute of the final submission.

Todo in this PR: 
- [x] Acknowledge revision on student dashboard, 

Future work:
- [ ] queues indicate which submissions have been revised, 
- [ ] grading interface support viewing two submissions 
- [ ] grading view should just diff between the two submissions. (Maybe?)  
