### PR TITLE
Stop logging an error on every api request 

### DIFF
--- a/server/app/auth.py
+++ b/server/app/auth.py
@@ -26,7 +26,7 @@ def authenticate():
         return models.User.get_or_insert("<anon>")
     else:
         access_token = request.args['access_token']
-        print 'USING ACCESS TOKEN', access_token
+        # print 'USING ACCESS TOKEN', access_token
         user = mc.get("%s-%s" % (MC_NAMESPACE, access_token))
         if user:
             return user


### PR DESCRIPTION
Silences the USING ACCESS TOKEN error that is polluting the logs.