### PR TITLE
Search

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1222,6 +1222,7 @@ class SearchAPI(APIResource):
         scope = SearchAPI.translate(tokens)
         prime = SearchAPI.objectify(scope)
         query = SearchAPI.querify(prime)
+        print(query.fetch())
         return query.fetch()
         
     
@@ -1260,9 +1261,9 @@ class SearchAPI(APIResource):
     def get_model(prime):
         """ determine model using passed-in data """
         if prime['submitted']:
-            return models.Submission
+            return models.FinalSubmission
         else:
-            return models.Backup
+            return models.Submission
     
     
     @staticmethod

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -891,7 +891,7 @@ class SubmissionAPI(APIResource):
         
     def data_for_zip(self, obj):
         try:
-            user = models.User(key=obj.submitter)
+            user = obj.submitter.get()
             name = user.email[0]+'-'+str(obj.created)
         except IndexError:
             name = str(obj.created)
@@ -1290,11 +1290,12 @@ class SearchAPI(APIResource):
         for result in results:
             try:
                 if isinstance(result, models.Submission):
-                    result = models.Backup(key=result.backup)
+                    result = result.backup.get()
                 name, file_contents = subm.data_for_zip(result)
                 zipfile = add_to_zip(zipfile, file_contents, name)
             except BadValueError as e:
-                pass
+                if str(e) != 'Submission has no contents to download':
+                    raise e
         return subm.make_zip_response('query', finish_zip(zipfile_str, zipfile))
 
     

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import ast
 import requests
+from zipfile import ZipFile
 
 from flask.views import View
 from flask.app import request, json
@@ -1232,6 +1233,10 @@ class SearchAPI(APIResource):
             results = self.index(user, data)['results']
         else:
             results = SearchAPI.querify(data['query']).fetch()
+        zip = ZipFile()
+        for i, result in enumerate(results):
+            zip.writestr(result.download())
+        return zip
 
     
     @staticmethod

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1194,7 +1194,7 @@ class SearchAPI(APIResource):
     }
     
     defaults = {
-        'onlywcode': (__eq__, 'True')
+        'onlywcode': (op.__eq__, 'True')
     }
     
     operators = {
@@ -1226,7 +1226,13 @@ class SearchAPI(APIResource):
             'results': results,
             'more': len(results) >= data['num_per_page']
         })
-        
+    
+    def download(self, user, data):
+        if data.get('all', False):
+            results = self.index(user, data)['results']
+        else:
+            results = SearchAPI.querify(data['query']).fetch()
+
     
     @staticmethod
     def tokenize(query):

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -890,7 +890,11 @@ class SubmissionAPI(APIResource):
         """
         
     def data_for_zip(self, obj):
-        name = obj.submitter.email+'-'+str(obj.created)
+        try:
+            user = models.User(key=obj.submitter)
+            name = user.email[0]+'-'+str(obj.created)
+        except IndexError:
+            name = str(obj.created)
         messages = obj.get_messages()
         if 'file_contents' not in messages:
             raise BadValueError('Submission has no contents to download')
@@ -1286,12 +1290,11 @@ class SearchAPI(APIResource):
             try:
                 if isinstance(result, models.Submission):
                     result = models.Backup(key=result.backup)
-                return subm.download(result, user, data)
                 name, file_contents = subm.data_for_zip(result)
                 zipfile = add_to_zip(zipfile, file_contents, name)
             except:
                 pass
-        # return subm.make_zip_response('query', finish_zip(zipfile_str, zipfile))
+        return subm.make_zip_response('query', finish_zip(zipfile_str, zipfile))
 
     
     @staticmethod

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1257,6 +1257,7 @@ class SearchAPI(APIResource):
         'after': op.__gt__
     }
     
+    # maps flags to processing functions (e.g., instantiate objects)
     flags = {
         'user': lambda op, email:
             UserAPI.model.query(

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1193,7 +1193,9 @@ class SearchAPI(APIResource):
         }
     }
     
-    defaults = {}
+    defaults = {
+        'onlywcode': (__eq__, 'True')
+    }
     
     operators = {
         'eq': op.__eq__,
@@ -1210,9 +1212,10 @@ class SearchAPI(APIResource):
                 op(UserAPI.model.email, email)).get(),
         'date': lambda op, s: datetime.datetime.strptime(s, '%Y-%m-%d'),
         'onlyfinal': lambda op, boolean: boolean.lower() == 'true',
+        'onlywcode': lambda op, boolean: boolean.lower() == 'true',
         'assignment': lambda op, name:
             AssignmentAPI.model.query(
-                op(AssignmentAPI.model.display_name, name)).get()
+                op(AssignmentAPI.model.display_name, name)).get(),
     }
 
     def index(self, user, data):
@@ -1287,6 +1290,9 @@ class SearchAPI(APIResource):
         if 'date' in keys:
             opr, arg = prime['date']
             args.append(opr(model.server_time, arg))
+        if 'onlywcode' in keys:
+            pass
+            # TODO: complete onlywcode : query only submissions that have code
         return args
     
     @staticmethod

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -900,6 +900,16 @@ class SubmissionAPI(APIResource):
             raise BadValueError('Submission has no contents to download')
         file_contents = messages['file_contents']
         
+        if 'submit' in file_contents:
+            del file_contents['submit']
+
+        # Need to encode every file before it is.
+        for key in file_contents.keys():
+            try:
+                file_contents[key] = file_contents[key].encode('utf-8')
+            except:
+                pass
+        
         return name, file_contents
         
     def zip(self, obj, user, data):
@@ -916,15 +926,6 @@ class SubmissionAPI(APIResource):
         :param file_contents:
         :return:
         """
-        if 'submit' in file_contents:
-            del file_contents['submit']
-
-        # Need to encode every file before it is.
-        for key in file_contents.keys():
-            try:
-                file_contents[key] = file_contents[key].encode('utf-8')
-            except:
-                pass
         zipfile = create_zip(file_contents)
         return name, zipfile
 
@@ -1292,7 +1293,7 @@ class SearchAPI(APIResource):
                     result = models.Backup(key=result.backup)
                 name, file_contents = subm.data_for_zip(result)
                 zipfile = add_to_zip(zipfile, file_contents, name)
-            except:
+            except BadValueError as e:
                 pass
         return subm.make_zip_response('query', finish_zip(zipfile_str, zipfile))
 

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1220,9 +1220,11 @@ class SearchAPI(APIResource):
         scope = SearchAPI.translate(tokens)
         prime = SearchAPI.objectify(scope)
         query = SearchAPI.querify(prime)
+        start, end = SearchAPI.limits(data['page'], data['num_per_page'])
+        results = query.fetch()[start:end]
         return dict(data={
-            'results': query.fetch(),
-            'more': False
+            'results': results,
+            'more': len(results) >= data['num_per_page']
         })
         
     
@@ -1269,6 +1271,7 @@ class SearchAPI(APIResource):
     
     @staticmethod
     def get_args(model, prime):
+        """ Creates all Filter Nodes """
         args, keys = [], prime.keys()
         if 'assignment' in keys:
             args.append(model.assignment == prime['assignment'][1].key)
@@ -1278,6 +1281,11 @@ class SearchAPI(APIResource):
             opr, arg = prime['date']
             args.append(opr(model.server_time, arg))
         return args
+    
+    @staticmethod
+    def limits(page, num_per_page):
+        """ returns start and ends number based on page and num_per_page """
+        return (page-1)*num_per_page, page*num_per_page
 
 
 class VersionAPI(APIResource):

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1193,9 +1193,7 @@ class SearchAPI(APIResource):
         }
     }
     
-    defaults = {
-        'submitted': (op.__eq__, True)
-    }
+    defaults = {}
     
     operators = {
         'eq': op.__eq__,
@@ -1211,7 +1209,7 @@ class SearchAPI(APIResource):
             UserAPI.model.query(
                 op(UserAPI.model.email, email)).get(),
         'date': lambda op, s: datetime.datetime.strptime(s, '%Y-%m-%d'),
-        'submitted': lambda op, boolean: bool(boolean),
+        'onlyfinal': lambda op, boolean: boolean.lower() == 'true',
         'assignment': lambda op, name:
             AssignmentAPI.model.query(
                 op(AssignmentAPI.model.display_name, name)).get()
@@ -1222,8 +1220,10 @@ class SearchAPI(APIResource):
         scope = SearchAPI.translate(tokens)
         prime = SearchAPI.objectify(scope)
         query = SearchAPI.querify(prime)
-        print(query.fetch())
-        return query.fetch()
+        return dict(data={
+            'results': query.fetch(),
+            'more': False
+        })
         
     
     @staticmethod
@@ -1260,7 +1260,8 @@ class SearchAPI(APIResource):
     @staticmethod
     def get_model(prime):
         """ determine model using passed-in data """
-        if prime['submitted']:
+        op, onlyfinal = prime.get('onlyfinal', (None, False))
+        if onlyfinal:
             return models.FinalSubmission
         else:
             return models.Submission

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -112,8 +112,6 @@ def add_to_zip(zipfile, file_contents, dir=''):
     Adds files to a given zip file. Uses specified dir to store files.
     """
     for filename, contents in file_contents.items():
-        if filename.endswith('.py'):
-            print(filename)
         zipfile.writestr(join(dir, filename), contents)
     return zipfile
 

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -112,6 +112,8 @@ def add_to_zip(zipfile, file_contents, dir=''):
     Adds files to a given zip file. Uses specified dir to store files.
     """
     for filename, contents in file_contents.items():
+        if filename.endswith('.py'):
+            print(filename)
         zipfile.writestr(join(dir, filename), contents)
     return zipfile
 

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -8,6 +8,7 @@ import collections
 import logging
 import datetime
 import itertools
+from os.path import join
 
 try:
     from cStringIO import StringIO
@@ -86,16 +87,33 @@ def create_api_response(status, message, data=None):
     response.status_code = status
     return response
 
-def create_zip(obj):
+
+def create_zip(file_contents={}, dir=''):
+    return finish_zip(*start_zip(file_contents, dir))
+
+
+def start_zip(file_contents={}, dir=''):
     """
     Creates a file from the given dictionary of filenames to contents.
+    Uses specified dir to store all files.
     """
     zipfile_str = StringIO()
-    with zf.ZipFile(zipfile_str, 'w') as zipfile:
-        for filename, contents in obj.items():
-            zipfile.writestr(filename, contents)
-    zip_string = zipfile_str.getvalue()
-    return zip_string
+    zipfile = zf.ZipFile(zipfile_str, 'w')
+    zipfile = add_to_zip(zipfile, file_contents, dir)
+    return zipfile_str, zipfile
+
+
+def finish_zip(zipfile_str, zipfile):
+    return zipfile_str.getvalue()
+
+
+def add_to_zip(zipfile, file_contents, dir=''):
+    """
+    Adds files to a given zip file. Uses specified dir to store files.
+    """
+    for filename, contents in file_contents.items():
+        zipfile.writestr(join(dir, filename), contents)
+    return zipfile
 
 def paginate(entries, page, num_per_page):
     """

--- a/server/index.yaml
+++ b/server/index.yaml
@@ -109,6 +109,11 @@ indexes:
   - name: server_time
     direction: desc
 
+- kind: Submissionv2
+  properties:
+  - name: submitter
+  - name: server_time
+
 - kind: Submissionvtwo
   properties:
   - name: assignment

--- a/server/index.yaml
+++ b/server/index.yaml
@@ -99,6 +99,11 @@ indexes:
 - kind: Submissionv2
   properties:
   - name: assignment
+  - name: server_time
+
+- kind: Submissionv2
+  properties:
+  - name: assignment
   - name: submitter
   - name: server_time
 

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -293,7 +293,6 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
         num_per_page: $scope.itemsPerPage,
       }, function(response) {
         $scope.submissions = response.data.results;
-        alert('YAY');
         if (response.data.more) {
           $scope.totalItems = $scope.currentPage * $scope.itemsPerPage + 1;
         } else {

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -314,23 +314,32 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
       $scope.getPage($scope.currentPage, $scope.query)
     }
     
-    $scope.download = function(all) {
+    $scope.download = function(query, page, itemsPerPage, all) {
       Search.download({
-        query: $scope.query.string,
+        query: query,
         page: page,
-        num_per_page: $scope.itemsPerPage,
-        all: all
+        num_per_page: itemsPerPage,
+        all: all,
+        "messages.kind": "file_contents"
       }, function (response) {
         console.log('Download!')
       })
     }
     
     $scope.downloadPage = function() {
-      $scope.download(false);
+      $scope.download(
+        $scope.query.string, 
+        $scope.currentPage, 
+        $scope.itemsPerPage, 
+        false);
     }
     
     $scope.downloadQuery = function() {
-      $scope.download(true);
+      $scope.download(
+        $scope.query.string,
+        $scope.currentPage, 
+        $scope.itemsPerPage, 
+        true);
     }
   }]);
 

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -286,9 +286,9 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
       'string': ''
     }
     
-    $scope.getPage = function(page, query) {
+    $scope.getPage = function(page) {
       Search.query({
-        query: query.string,
+        query: $scope.query.string,
         page: page,
         num_per_page: $scope.itemsPerPage,
       }, function(response) {
@@ -307,7 +307,7 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
       $scope.getPage($scope.currentPage);
     }
     
-    $scope.getPage(1, $scope.query);
+    $scope.getPage(1);
     
     $scope.search = function() {
       $scope.getPage($scope.currentPage, $scope.query)

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -307,6 +307,8 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
       $scope.getPage($scope.currentPage);
     }
     
+    $scope.getPage(1, $scope.query);
+    
     $scope.search = function() {
       $scope.getPage($scope.currentPage, $scope.query)
     }

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -293,6 +293,7 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
         num_per_page: $scope.itemsPerPage,
       }, function(response) {
         $scope.submissions = response.data.results;
+        alert('YAY');
         if (response.data.more) {
           $scope.totalItems = $scope.currentPage * $scope.itemsPerPage + 1;
         } else {

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -294,6 +294,7 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
       }, function(response) {
         $scope.submissions = response.data.results;
         $scope.more = response.data.more;
+        $scope.search_query = encodeURIComponent(response.data.query);
         if (response.data.more) {
           $scope.totalItems = $scope.currentPage * $scope.itemsPerPage + 1;
         } else {
@@ -312,34 +313,6 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
     
     $scope.search = function() {
       $scope.getPage($scope.currentPage, $scope.query)
-    }
-    
-    $scope.download = function(query, page, itemsPerPage, all) {
-      Search.download({
-        query: query,
-        page: page,
-        num_per_page: itemsPerPage,
-        all: all,
-        "messages.kind": "file_contents"
-      }, function (response) {
-        console.log('Download!')
-      })
-    }
-    
-    $scope.downloadPage = function() {
-      $scope.download(
-        $scope.query.string, 
-        $scope.currentPage, 
-        $scope.itemsPerPage, 
-        false);
-    }
-    
-    $scope.downloadQuery = function() {
-      $scope.download(
-        $scope.query.string,
-        $scope.currentPage, 
-        $scope.itemsPerPage, 
-        true);
     }
   }]);
 

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -288,11 +288,12 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
     
     $scope.getPage = function(page) {
       Search.query({
-        query: $scope.query.string,
+        query: $scope.query.string || '',
         page: page,
         num_per_page: $scope.itemsPerPage,
       }, function(response) {
         $scope.submissions = response.data.results;
+        $scope.more = response.data.more;
         if (response.data.more) {
           $scope.totalItems = $scope.currentPage * $scope.itemsPerPage + 1;
         } else {

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -312,6 +312,25 @@ app.controller("SubmissionListCtrl", ['$scope', '$window', 'Search',
     $scope.search = function() {
       $scope.getPage($scope.currentPage, $scope.query)
     }
+    
+    $scope.download = function(all) {
+      Search.download({
+        query: $scope.query.string,
+        page: page,
+        num_per_page: $scope.itemsPerPage,
+        all: all
+      }, function (response) {
+        console.log('Download!')
+      })
+    }
+    
+    $scope.downloadPage = function() {
+      $scope.download(false);
+    }
+    
+    $scope.downloadQuery = function() {
+      $scope.download(true);
+    }
   }]);
 
 

--- a/server/static/js/common/services.js
+++ b/server/static/js/common/services.js
@@ -385,12 +385,6 @@ app.factory('Search', ['$resource',
             transformResponse: function(data) {
               return JSON.parse(data).data;
             }
-          },
-          download: {
-            url: '/api/v1/download',
-            transformResponse: function(data) {
-              return JSON.parse(data).data;
-            }
           }
         }
       )

--- a/server/static/js/common/services.js
+++ b/server/static/js/common/services.js
@@ -386,6 +386,12 @@ app.factory('Search', ['$resource',
               return JSON.parse(data).data;
             }
           },
+          download: {
+            url: '/api/v1/download',
+            transformResponse: function(data) {
+              return JSON.parse(data).data;
+            }
+          }
         }
       )
     }

--- a/server/static/partials/admin/sidebar.module.html
+++ b/server/static/partials/admin/sidebar.module.html
@@ -40,7 +40,7 @@
                 <li><a ui-sref='course.list' style="margin-left: 20px;"><i class="fa fa-list"></i> All Courses</a> </li>
             </ul>
             <ul class="treeview-menu" style="display: block;" >
-                <li><a ui-sref='submission.list' style="margin-left: 20px;"><i class="fa fa-search"></i> All Submissions</a> </li>
+                <li><a ui-sref='submission.list' style="margin-left: 20px;"><i class="fa fa-search"></i> Submissions</a> </li>
             </ul>
         </li>
 

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -15,9 +15,9 @@
                     by one hyphen, a flag by two, and a string in double quotations or no punctuation at all.
                     Dates, for example, or any other name with hyphens must be enclosed by double quotations.
                     Missing comparison operators are automaticaly assumed to be --equal.<br><br>
-                    Available flags: user (email), date (YYYY-MM-DD), assignment (name), submitted (true/false)<br>
+                    Available flags: user (email), date (YYYY-MM-DD), assignment (name), onlysubmitted (true/false)<br>
                     Available operators: after, before, lt, gt, equal, eq (alias for equal)<br>
-                    Example: -user "test@example.com" -date --before "2015-06-22" -assignment Scheme -submitted true</p>
+                    Example: -user "partner0@teamwork.com" -date --before "2015-06-22" -assignment Scheme -onlysubmitted true</p>
                 <input type="text" placeholder="Search" class="form-control" ng-model="query.string" required/>
                 </select>
             </div>
@@ -51,7 +51,7 @@
           <th style="width: 15%">Tags</th>
       </tr>
 
-        <tr ng-repeat="submission in submissions" ng-if='submission.messages.file_contents' ts-repeat>
+        <tr ng-repeat="submission in submissions" ts-repeat>
           <td>
             <a ui-sref='assignment.detail({assignmentId:submission.assignment.id})'>{{submission.assignment.display_name}}
           </td>
@@ -61,9 +61,9 @@
           </td>
           <td>
               <div class="btn-group download-btn-group">
-                  <a ui-sref='submission.detail({submissionId:submission.id})' type="button" class="btn btn-flat btn-info">View</a>
-                  <a href='/api/v1/submission/{{submission.id}}/download' type="button" class="btn btn-flat btn-info">Download</a>
-                  <a ui-sref='submission.diff({submissionId:submission.id})' type="button" class="btn btn-flat btn-info">Diff</a>
+                  <!--<a ui-sref='submission.detail({submissionId:submission.id})' type="button" class="btn btn-flat btn-info">View</a>-->
+                  <!--<a href='/api/v1/submission/{{submission.id}}/download' type="button" class="btn btn-flat btn-info">Download</a>-->
+                  <!--<a ui-sref='submission.diff({submissionId:submission.id})' type="button" class="btn btn-flat btn-info">Diff</a>-->
               </div>
           </td>
           <!-- Future Progress Bar -->

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -15,9 +15,9 @@
                     by one hyphen, a flag by two, and a string in double quotations or no punctuation at all.
                     Dates, for example, or any other name with hyphens must be enclosed by double quotations.
                     Missing comparison operators are automaticaly assumed to be --equal.<br><br>
-                    Available flags: user (email), date (YYYY-MM-DD), assignment (name), onlysubmitted (true/false)<br>
+                    Available flags: user (email), date (YYYY-MM-DD), assignment (name), onlyfinal (true/false)<br>
                     Available operators: after, before, lt, gt, equal, eq (alias for equal)<br>
-                    Example: -user "partner0@teamwork.com" -date --before "2015-06-22" -assignment Scheme -onlysubmitted true</p>
+                    Example: -user "partner0@teamwork.com" -date --before "2015-06-22" -assignment Hog -onlyfinal false</p>
                 <input type="text" placeholder="Search" class="form-control" ng-model="query.string" required/>
                 </select>
             </div>
@@ -47,25 +47,25 @@
           <th ts-criteria="assignment.display_name">Assignment</th>
           <th ts-criteria="submitter.id" >Submitter</th>
           <th ts-criteria="created">Time</th>
-          <th style="width: 20%">View Code</th>
-          <th style="width: 15%">Tags</th>
+          <!--<th style="width: 20%">View Code</th>-->
+          <th>Tags</th>
       </tr>
 
         <tr ng-repeat="submission in submissions" ts-repeat>
           <td>
             <a ui-sref='assignment.detail({assignmentId:submission.assignment.id})'>{{submission.assignment.display_name}}
           </td>
-          <td>{{submission.submitter.id}}</td>
+          <td>{{submission.submitter.email[0]}}</td>
           <td>
             {{submission.created | amCalendar}}
           </td>
-          <td>
-              <div class="btn-group download-btn-group">
+          <!--<td>-->
+              <!--<div class="btn-group download-btn-group">-->
                   <!--<a ui-sref='submission.detail({submissionId:submission.id})' type="button" class="btn btn-flat btn-info">View</a>-->
                   <!--<a href='/api/v1/submission/{{submission.id}}/download' type="button" class="btn btn-flat btn-info">Download</a>-->
                   <!--<a ui-sref='submission.diff({submissionId:submission.id})' type="button" class="btn btn-flat btn-info">Diff</a>-->
-              </div>
-          </td>
+              <!--</div>-->
+          <!--</td>-->
           <!-- Future Progress Bar -->
           <td >
             <span class="badge bg-info">{{submission.assignment.display_name}}</span>

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -15,9 +15,9 @@
                     by one hyphen, a flag by two, and a string in double quotations or no punctuation at all.
                     Dates, for example, or any other name with hyphens must be enclosed by double quotations.
                     Missing comparison operators are automaticaly assumed to be --equal.<br><br>
-                    Available flags: user, date (YYYY-MM-DD), submitted, assignment<br>
-                    Available operators: after, before, lt, gt, equal, eq (alias for equal), startswith, endswith<br>
-                    Example: -user "test@example.com" -date --before "2015-06-22" -submitted true -assignment --startswith Scheme</p>
+                    Available flags: user, date (YYYY-MM-DD), assignment<br>
+                    Available operators: after, before, lt, gt, equal, eq (alias for equal)å<br>
+                    Example: -user "test@example.com" -date --before "2015-06-22" -assignment Scheme</p>
                 <input type="text" placeholder="Search" class="form-control" ng-model="query.string" required/>
                 </select>
             </div>

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -32,14 +32,14 @@
       <h3 class="box-title" ng-if="submissions.length > 0">All Submissions</h3>
       <h4 class="box-title" ng-if="submissions.length == 0" >No Submissions</h3>
       <div class="box-tools" style="float:right;">
-          <button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" style="margin-right:5px"> <i class="fa fa-download"></i>  Download All</button>
-          <button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1"> <i class="fa fa-download"></i>  Download Page</button>
-          <button class="btn btn-primary btn-sm" ng-if="!more && currentPage == 1"> <i class="fa fa-download"></i>  Download</button>
+          <button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" ng-click="downloadPage()" style="margin-right:5px"> <i class="fa fa-download"></i>  Download All</button>
+          <button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" ng-click="downloadQuery()"> <i class="fa fa-download"></i>  Download Page</button>
+          <button class="btn btn-primary btn-sm" ng-if="!more && currentPage == 1" ng-click="downloadQuery()"> <i class="fa fa-download"></i>  Download</button>
       </div>
     </div>
     <!-- /.box-header -->
 
-    <div class="box-body no-padding table-responsive">
+    <div class="box-body table-responsive">
 
         <div class='text-center'>
           <pager items-per-page="itemsPerPage" total-items="totalItems" ng-model="currentPage" ng-change="pageChanged()"></pager>

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -15,7 +15,7 @@
                     by one hyphen, a flag by two, and a string in double quotations or no punctuation at all.
                     Dates, for example, or any other name with hyphens must be enclosed by double quotations.
                     Missing comparison operators are automaticaly assumed to be --equal.<br><br>
-                    Available flags: user (email), date (YYYY-MM-DD), assignment (name), onlyfinal (true/false)<br>
+                    Available flags: user (email), date (YYYY-MM-DD), assignment (name), onlyfinal (true/false), onlybackup (true/false)<br>
                     Available operators: after, before, lt, gt, equal, eq (alias for equal)<br>
                     Example: -user "partner0@teamwork.com" -date --before "2015-06-22" -assignment Hog -onlyfinal false</p>
                 <input type="text" placeholder="Search" class="form-control" ng-model="query.string" required/>

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -64,13 +64,6 @@
           <td>
             {{submission.created | amCalendar}}
           </td>
-          <!--<td>-->
-              <!--<div class="btn-group download-btn-group">-->
-                  <!--<a ui-sref='submission.detail({submissionId:submission.id})' type="button" class="btn btn-flat btn-info">View</a>-->
-                  <!--<a href='/api/v1/submission/{{submission.id}}/download' type="button" class="btn btn-flat btn-info">Download</a>-->
-                  <!--<a ui-sref='submission.diff({submissionId:submission.id})' type="button" class="btn btn-flat btn-info">Diff</a>-->
-              <!--</div>-->
-          <!--</td>-->
           <!-- Future Progress Bar -->
           <td >
             <span class="badge bg-info">{{submission.assignment.display_name}}</span>
@@ -81,11 +74,6 @@
             </span>
 
           </td>
-    <!--       <td ng-show="submission.assignment.active">
-              <button ng-click='submitVersion(submission.id);' ng-disabled="clicked" type="button" class="btn btn-flat btn-success" ng-if="submission.tags.indexOf('Submit') <= -1">Submit</button>
-              <button ng-click='unSubmit(submission.id);' ng-disabled="clicked" type="button" class="btn btn-flat btn-danger" ng-if="submission.tags.indexOf('Submit') > -1">Un-submit</button>
-          </td>
-     -->
         </tr>
       </tbody>
     </table>

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -15,9 +15,9 @@
                     by one hyphen, a flag by two, and a string in double quotations or no punctuation at all.
                     Dates, for example, or any other name with hyphens must be enclosed by double quotations.
                     Missing comparison operators are automaticaly assumed to be --equal.<br><br>
-                    Available flags: user, date (YYYY-MM-DD), assignment<br>
-                    Available operators: after, before, lt, gt, equal, eq (alias for equal)å<br>
-                    Example: -user "test@example.com" -date --before "2015-06-22" -assignment Scheme</p>
+                    Available flags: user (email), date (YYYY-MM-DD), assignment (name), submitted (true/false)<br>
+                    Available operators: after, before, lt, gt, equal, eq (alias for equal)<br>
+                    Example: -user "test@example.com" -date --before "2015-06-22" -assignment Scheme -submitted true</p>
                 <input type="text" placeholder="Search" class="form-control" ng-model="query.string" required/>
                 </select>
             </div>

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -15,9 +15,9 @@
                     by one hyphen, a flag by two, and a string in double quotations or no punctuation at all.
                     Dates, for example, or any other name with hyphens must be enclosed by double quotations.
                     Missing comparison operators are automaticaly assumed to be --equal.<br><br>
-                    Available flags: user, date, submitted, assignment, caseSensitive<br>
-                    Available operators: after, before, lt, gt, equal, eq (alias for equal), startswith, endswith, contains<br>
-                    Example: -user "test@example.com" -date --before "2015-06-22" -submitted true -assignment --contains Scheme</p>
+                    Available flags: user, date (YYYY-MM-DD), submitted, assignment<br>
+                    Available operators: after, before, lt, gt, equal, eq (alias for equal), startswith, endswith<br>
+                    Example: -user "test@example.com" -date --before "2015-06-22" -submitted true -assignment --startswith Scheme</p>
                 <input type="text" placeholder="Search" class="form-control" ng-model="query.string" required/>
                 </select>
             </div>

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -32,9 +32,9 @@
       <h3 class="box-title" ng-if="submissions.length > 0">All Submissions</h3>
       <h4 class="box-title" ng-if="submissions.length == 0" >No Submissions</h3>
       <div class="box-tools" style="float:right;">
-          <button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" ng-click="downloadPage()" style="margin-right:5px"> <i class="fa fa-download"></i>  Download All</button>
-          <button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" ng-click="downloadQuery()"> <i class="fa fa-download"></i>  Download Page</button>
-          <button class="btn btn-primary btn-sm" ng-if="!more && currentPage == 1" ng-click="downloadQuery()"> <i class="fa fa-download"></i>  Download</button>
+          <a href="/api/v1/search/download?all=true&query={{ search_query }}"><button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" style="margin-right:5px"> <i class="fa fa-download"></i>  Download All</button></a>
+          <a href="/api/v1/search/download?all=false&query={{ search_query }}"><button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" href="/api/v1/search/download"> <i class="fa fa-download"></i>  Download Page</button></a>
+          <a href="/api/v1/search/download?all=true&query={{ search_query }}"><button class="btn btn-primary btn-sm" ng-if="!more && currentPage == 1" href="/api/v1/search/download"> <i class="fa fa-download"></i>  Download</button></a>
       </div>
     </div>
     <!-- /.box-header -->

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -31,6 +31,11 @@
     <div class="box-header">
       <h3 class="box-title" ng-if="submissions.length > 0">All Submissions</h3>
       <h4 class="box-title" ng-if="submissions.length == 0" >No Submissions</h3>
+      <div class="box-tools" style="float:right;">
+          <button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" style="margin-right:5px"> <i class="fa fa-download"></i>  Download All</button>
+          <button class="btn btn-primary btn-sm" ng-if="more || currentPage != 1"> <i class="fa fa-download"></i>  Download Page</button>
+          <button class="btn btn-primary btn-sm" ng-if="!more && currentPage == 1"> <i class="fa fa-download"></i>  Download</button>
+      </div>
     </div>
     <!-- /.box-header -->
 


### PR DESCRIPTION
Search, available through the admin panel "<strike>All</strike> Submissions":

<strike>*Doesn't actually work yet. The code runs without errors and the tokenization/parsing is correct, but I may need to check on KeyArgs or something like that.</strike> Functional!

Of course, tags can be mixed and matched in any way; here are two demos:

![site-submissions-search](https://cloud.githubusercontent.com/assets/2068077/8250064/2c4cd0a8-1625-11e5-86b2-ada1b8334ff5.gif)

![site-submissions-search2](https://cloud.githubusercontent.com/assets/2068077/8250109/9ed19334-1625-11e5-822e-c17d74dc0016.gif)

> **Note**: The date tag only works when -onlyfinal is false (or not specified at all); basically, the FinalSubmission table doesn't have a "server_time" field. Right now, the -onlyfinal tag actually changes the model that the search queries. Instead, it should probably add a filter that checks for final. I can/will file an issue when this is merged.

**Description**

All searches are composed of flags, operators, and their associated value. A flag is denoted by one hyphen, a flag by two, and a string in double quotations or no punctuation at all. Dates, for example, or any other name with hyphens must be enclosed by double quotations. Missing comparison operators are automaticaly assumed to be --equal.

Available flags: user (email), date (YYYY-MM-DD), assignment (name), onlyfinal (true/false)
Available operators: after, before, lt, gt, equal, eq (alias for equal)
Example: -user "test@example.com" -date --before "2015-06-22" -assignment Hog -onlyfinal true

**How it works**

1. Regex match, find all flags, operators, and arguments.
2. Convert all operators to their related functions, imported from operator.
3. Convert arguments to objects where necessary.
4. Compile FilterNodes, using operators on the proper model attribute and argument.
5. Create query using FilterNodes.
6. Query, and return.

fixes #305, #445, #444 