### PR TITLE
Sweetalert js Source

### DIFF
--- a/server/app/templates/admin.html
+++ b/server/app/templates/admin.html
@@ -19,7 +19,7 @@
         <link href="/static/css/main.css" rel="stylesheet" type="text/css" />
 
         <link href="/static/vendor/angular-loading-bar/build/loading-bar.css" rel="stylesheet"></link>
-        <link href="/static/vendor/sweetalert/dist/sweet-alert.css" rel="stylesheet"></link>
+        <link href="/static/vendor/sweetalert/dist/sweetalert.css" rel="stylesheet"></link>
         <link href="/static/vendor/angular-tablesort/tablesort.css" rel="stylesheet"></link>
 
 
@@ -45,7 +45,7 @@
         <script src="/static/vendor/angular-moment/angular-moment.js"></script>
         <script src="/static/vendor/showdown/compressed/Showdown.js"></script>
         <script src="/static/vendor/jquery.tablesorter/js/jquery.tablesorter.min.js"></script>
-        <script src="/static/vendor/sweetalert/dist/sweet-alert.min.js"></script>
+        <script src="/static/vendor/sweetalert/dist/sweetalert.min.js"></script>
         <script src="/static/vendor/ngstorage/ngStorage.js"></script>
         <script src="/static/vendor/angular-tablesort/js/angular-tablesort.js"></script>
 

--- a/server/app/templates/student.html
+++ b/server/app/templates/student.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
         <link href="/static/vendor/angular-loading-bar/build/loading-bar.css" rel="stylesheet">
 
-        <link href="/static/vendor/sweetalert/dist/sweet-alert.css" rel="stylesheet">
+        <link href="/static/vendor/sweetalert/dist/sweetalert.css" rel="stylesheet">
         <link href="/static/vendor/highlightjs/styles/github.css" rel="stylesheet">
 
         <link href="/static/vendor/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -32,7 +32,7 @@
         <script src="/static/js/other/moment-timezone-with-data.js"></script>
         <script src="/static/vendor/angular-moment/angular-moment.js"></script>
         <script src="/static/vendor/showdown/compressed/Showdown.js"></script>
-        <script src="/static/vendor/sweetalert/dist/sweet-alert.min.js"></script>
+        <script src="/static/vendor/sweetalert/dist/sweetalert.min.js"></script>
         <script src="/static/vendor/angular-tablesort/js/angular-tablesort.js"></script>
         <script src="/static/vendor/angular-ui-sortable/sortable.js"></script>
 


### PR DESCRIPTION
Reverts Cal-CS-61A-Staff/ok#488

It's no longer sweet-alert - that 404s https://ok-server.appspot.com/static/vendor/sweetalert/dist/sweet-alert.min.js

Its sweetalert.js/css  (https://ok-server.appspot.com/static/vendor/sweetalert/dist/sweetalert.min.js)

