### PR TITLE
Travis Speed Up (Cache)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,20 @@ env:
 python:
   - "2.7"
 
-install: pip install -r server_requirements.txt
+install:
+  - pip install -r server_requirements.txt
 
-script: FLASK_CONF=TEST coverage run --source=server $CMD --sdk_location $GAE_SDK --quiet
+script:
+  - FLASK_CONF=TEST coverage run --source=server $CMD --sdk_location $GAE_SDK --quiet
 
 before_script:
-  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -o gae_sdk.zip
-  - unzip -q google_appengine_$GAE_VERSION.zip
-  - mv google_appengine gae_sdk
-  - export GAE_SDK=$PWD/gae_sdk
-  - export PATH=$PATH:$GAE_SDK
-  - export PYTHONPATH=$PYTHONPATH:$GAE_SDK
-  - python server/app/generate_keys.py
+  - bash server/before_script.sh
 
 after_success:
   - coveralls
   
 sudo: false
+
+cache:
+  directories:
+  - /home/travis/virtualenv/python2.7.9/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,13 @@ script:
   - FLASK_CONF=TEST coverage run --source=server $CMD --sdk_location $GAE_SDK --quiet
 
 before_script:
-  - bash server/before_script.sh
+  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -o gae_sdk.zip
+  - unzip -q google_appengine_$GAE_VERSION.zip
+  - mv google_appengine gae_sdk
+  - export GAE_SDK=$PWD/gae_sdk
+  - export PATH=$PATH:$GAE_SDK
+  - export PYTHONPATH=$PYTHONPATH:$GAE_SDK
+  - python server/app/generate_keys.py
 
 after_success:
   - coveralls

--- a/server/before_script.sh
+++ b/server/before_script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -o gae_sdk.zip
+unzip -q google_appengine_$GAE_VERSION.zip
+mv google_appengine gae_sdk
+export GAE_SDK=$PWD/gae_sdk
+export PATH=$PATH:$GAE_SDK
+export PYTHONPATH=$PYTHONPATH:$GAE_SDK
+python server/app/generate_keys.py

--- a/server/before_script.sh
+++ b/server/before_script.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -o gae_sdk.zip
-unzip -q google_appengine_$GAE_VERSION.zip
-mv google_appengine gae_sdk
-export GAE_SDK=$PWD/gae_sdk
-export PATH=$PATH:$GAE_SDK
-export PYTHONPATH=$PYTHONPATH:$GAE_SDK
-python server/app/generate_keys.py


### PR DESCRIPTION
Ended up only adding a few lines to `.travis.yml`. (Every run will stick check dependencies for compliance. Old versions are just cached.)

- On average, `pip install -r requirements.txt` has been reduced from ~20s to ~2s.
- uses travis's new "container-based infrastructure" - improved testing time to ~1-1.5 minutes, from ~1.5-2 minutes and all runs within 10s