### PR TITLE
Cron Job config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install -r server_requirements.txt
 
 script:
-  - FLASK_CONF=TEST coverage run --source=server $CMD --sdk_location $GAE_SDK --quiet
+  - FLASK_CONF=TEST coverage run $CMD --sdk_location $GAE_SDK --quiet
 
 before_script:
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -o gae_sdk.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "2.7"
 
 install:
+  - pip install pip --upgrade
   - pip install -r server_requirements.txt
 
 script:

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,5 +1,5 @@
 cron:
 - description: Ok Daily Backup
   url: /_ah/datastore_admin/backup.create?name=2015DailyBackup&kind=Submissionv2&kind=Userv2&filesystem=gs&gs_bucket_name=ok_2015_backups
-  schedule: every 24 hours
+  schedule: every day 17:00
   target: ah-builtin-python-bundle

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,5 +1,5 @@
 cron:
 - description: Ok Daily Backup
-  url: /_ah/datastore_admin/backup.create?name=2015DailyBackup&kind=FinalSubmissionv2&kind=Userv2&filesystem=gs&gs_bucket_name=ok_2015_backups
+  url: /_ah/datastore_admin/backup.create?name=2015DailyBackup&kind=Submissionv2&kind=Userv2&filesystem=gs&gs_bucket_name=ok_2015_backups
   schedule: every 24 hours
   target: ah-builtin-python-bundle

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,0 +1,5 @@
+cron:
+- description: Ok Daily Backup
+  url: /_ah/datastore_admin/backup.create?name=2015DailyBackup&kind=FinalSubmissionv2&kind=Userv2&filesystem=gs&gs_bucket_name=ok_2015_backups
+  schedule: every 24 hours
+  target: ah-builtin-python-bundle

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,5 +1,5 @@
 cron:
 - description: Ok Daily Backup
-  url: /_ah/datastore_admin/backup.create?name=2015DailyBackup&kind=Submissionv2&kind=Userv2&filesystem=gs&gs_bucket_name=ok_2015_backups
+  url: /_ah/datastore_admin/backup.create?name=2015DailyBackup&kind=FinalSubmissionv2&kind=Submissionv2&kind=Userv2&filesystem=gs&gs_bucket_name=ok_2015_backups
   schedule: every day 17:00
   target: ah-builtin-python-bundle

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,5 +1,6 @@
 cron:
 - description: Ok Daily Backup
   url: /_ah/datastore_admin/backup.create?name=2015DailyBackup&kind=FinalSubmissionv2&kind=Submissionv2&kind=Userv2&filesystem=gs&gs_bucket_name=ok_2015_backups
-  schedule: every day 17:00
+  schedule: every day 03:00
+  timezone: America/Los_Angeles
   target: ah-builtin-python-bundle

--- a/server/tests/unittests/test_backup.py
+++ b/server/tests/unittests/test_backup.py
@@ -54,8 +54,6 @@ BACKUP_TESTS = [
          "student0", "Backup", "first", "modify", False),
 ]
 
-# TODO: Better place for Submission tests.
-
 #pylint: disable=no-init, missing-docstring
 @ddt
 class BackupPermissionsUnitTest(PermissionsUnitTest):


### PR DESCRIPTION
When deployed with GAE, script will launch a daily backup of all users and final submissions.

[Reference](https://cloud.google.com/appengine/articles/scheduled_backups)

@soumyabasu @Sumukh Ready.