### PR TITLE
Restores coveralls check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install -r server_requirements.txt
 
 script:
-  - FLASK_CONF=TEST coverage run --source=server $CMD --sdk_location $GAE_SDK --quiet
+  - FLASK_CONF=TEST coverage run $CMD --sdk_location $GAE_SDK --quiet
 
 before_script:
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_$GAE_VERSION.zip -o gae_sdk.zip


### PR DESCRIPTION
by removing `--source` flag

@soumyabasu @Sumukh Can we merge this one? Since it's not a good idea to merge/deploy the cron job script, I decided to cherry-pick this commit out from that branch first.

*Travis is failing, because the commits removing `user.status` tests are not included.