### PR TITLE
Fixed zip download

### DIFF
--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -108,6 +108,7 @@ def start_zip(file_contents={}, dir=''):
 
 
 def finish_zip(zipfile_str, zipfile):
+    zipfile.close()
     return zipfile_str.getvalue()
 
 


### PR DESCRIPTION
one-liner

@soumyabasu @Sumukh Ready.

Zip downloads weren't working... because I didn't close... I removed the `with` block at some point and that broke things.