### PR TITLE
deferred invokes self if timeout

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1433,7 +1433,8 @@ class SearchAPI(APIResource):
         self.check_permissions(user, data)
 
         now = datetime.datetime.now()
-        deferred.defer(subms_to_gcs, SearchAPI, SubmissionAPI, models.Submission, user, data, now)
+        deferred.defer(subms_to_gcs, SearchAPI, SubmissionAPI, 
+                       models.Submission, user, data, now)
         
         return [make_zip_filename(user, now)]
 


### PR DESCRIPTION
I'm not actually sure if this will fix the problem

@Sumukh @soumyabasu Could you guys take a look? At some point or another, I can integrate with `mapper.py` and somehow generalize `mapper.py` for more than analytics.

Until then, the function that writes to gcs will invoke itself on timeout, while it's querying the database and writing to the string buffer. Caveat: if it times out while writing contents to a zip file... it dies.

fixes #557 