### PR TITLE
Fix group API member lookup

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -839,15 +839,15 @@ class AssignmentAPI(APIResource):
 
     def download_scores(self, obj, user, data):
         """
-        Write all composition scores for this assignment as a GCS file. 
+        Write all composition scores for this assignment as a GCS file.
         Format is 'STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG'.
         """
         need = Need('staff')
         if not obj.can(user, need, obj):
             raise need.exception()
-        
+
         deferred.defer(scores_to_gcs, obj, user)
-        
+
     def autograde(self, obj, user, data):
       need = Need('grade')
       if not obj.can(user, need, obj):
@@ -1407,7 +1407,7 @@ class SearchAPI(APIResource):
 
         if user.key not in course.staff and not user.is_admin:
             raise Need('get').exception()
-    
+
     @staticmethod
     def results(data):
         """ Returns results of query, limiting results accordingly """
@@ -1434,7 +1434,7 @@ class SearchAPI(APIResource):
 
         now = datetime.datetime.now()
         deferred.defer(subms_to_gcs, SearchAPI, SubmissionAPI, models.Submission, user, data, now)
-        
+
         return [make_zip_filename(user, now)]
 
 
@@ -1811,7 +1811,7 @@ class GroupAPI(APIResource):
         'index': {
             'web_args': {
                 'assignment': KeyArg('Assignment'),
-                'members': KeyArg('User')
+                'member': KeyArg('User')
             }
         },
         'add_member': {

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1784,7 +1784,7 @@ class CourseAPI(APIResource):
             raise need.exception()
 
         user = models.User.get_or_insert(data['email'])
-        models.Partficipant.add_role(user, course, STUDENT_ROLE)
+        models.Participant.add_role(user, course, STUDENT_ROLE)
 
     def remove_student(self, course, user, data):
         need = Need('staff')

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1784,7 +1784,7 @@ class CourseAPI(APIResource):
             raise need.exception()
 
         user = models.User.get_or_insert(data['email'])
-        models.Participant.add_role(user, course, STUDENT_ROLE)
+        models.Partficipant.add_role(user, course, STUDENT_ROLE)
 
     def remove_student(self, course, user, data):
         need = Need('staff')

--- a/server/index.yaml
+++ b/server/index.yaml
@@ -71,6 +71,12 @@ indexes:
   - name: created
     direction: desc
 
+- kind: Groupv2
+  properties:
+  - name: member
+  - name: created
+    direction: desc
+
 - kind: Participantv2
   properties:
   - name: course

--- a/server/tests/integration/test_api_group.py
+++ b/server/tests/integration/test_api_group.py
@@ -51,6 +51,19 @@ class GroupAPITest(APITest, APIBaseTestCase):
 		self.get('/assignment/{}/group'.format(self.assignment.key.id()))
 		self.assertEqual(self.response_json['id'], inst.key.id())
 
+  def test_index_arguments(self):
+    self.user = self.accounts['dummy_student2']
+    self.partner = self.accounts['dummy_student3']
+    inst = self.get_basic_instance()
+    inst.put()
+
+    self.get_index(assignment=self.assignment.key.id(), member=self.user.key.id())
+    self.assertEqual(self.response_json[0]['id'], inst.key.id())
+
+    self.get_index(member=self.partner.key.id())
+    self.assertEqual(self.response_json[0]['id'], inst.key.id())
+
+
 	def test_assignment_invite(self):
 		self.user = self.accounts['dummy_student2']
 		inst = self.get_basic_instance()

--- a/server/tests/integration/test_api_group.py
+++ b/server/tests/integration/test_api_group.py
@@ -21,35 +21,35 @@ from integration.test_api_base import APITest
 
 
 class GroupAPITest(APITest, APIBaseTestCase):
-	model = models.Group
-	name = 'group'
-	num = 1
-	access_token = 'dummy_admin'
+  model = models.Group
+  name = 'group'
+  num = 1
+  access_token = 'dummy_admin'
 
-	def setUp(self):
-		super(GroupAPITest, self).setUp()
-		self.course = make_fake_course(self.user)
-		self.course.put()
-		self.assignment = make_fake_assignment(self.course, self.user)
-		self.assignment.put()
-		for student_name in [a for a in self.accounts if 'student' in a]:
-			s = self.accounts[student_name]
-			models.Participant.add_role(s, self.course, constants.STUDENT_ROLE)
+  def setUp(self):
+    super(GroupAPITest, self).setUp()
+    self.course = make_fake_course(self.user)
+    self.course.put()
+    self.assignment = make_fake_assignment(self.course, self.user)
+    self.assignment.put()
+    for student_name in [a for a in self.accounts if 'student' in a]:
+      s = self.accounts[student_name]
+      models.Participant.add_role(s, self.course, constants.STUDENT_ROLE)
 
-	def get_basic_instance(self, mutate=True):
-		return self.model(
-			assignment=self.assignment.key,
-			member=[
-				self.accounts['dummy_student2'].key,
-				self.accounts['dummy_student3'].key])
+  def get_basic_instance(self, mutate=True):
+    return self.model(
+      assignment=self.assignment.key,
+      member=[
+        self.accounts['dummy_student2'].key,
+        self.accounts['dummy_student3'].key])
 
-	def test_assignment_group(self):
-		self.user = self.accounts['dummy_student2']
-		inst = self.get_basic_instance()
-		inst.put()
+  def test_assignment_group(self):
+    self.user = self.accounts['dummy_student2']
+    inst = self.get_basic_instance()
+    inst.put()
 
-		self.get('/assignment/{}/group'.format(self.assignment.key.id()))
-		self.assertEqual(self.response_json['id'], inst.key.id())
+    self.get('/assignment/{}/group'.format(self.assignment.key.id()))
+    self.assertEqual(self.response_json['id'], inst.key.id())
 
   def test_index_arguments(self):
     self.user = self.accounts['dummy_student2']
@@ -64,123 +64,123 @@ class GroupAPITest(APITest, APIBaseTestCase):
     self.assertEqual(self.response_json[0]['id'], inst.key.id())
 
 
-	def test_assignment_invite(self):
-		self.user = self.accounts['dummy_student2']
-		inst = self.get_basic_instance()
-		inst.put()
+  def test_assignment_invite(self):
+    self.user = self.accounts['dummy_student2']
+    inst = self.get_basic_instance()
+    inst.put()
 
-		invited = self.accounts['dummy_student']
-		invited.put()
+    invited = self.accounts['dummy_student']
+    invited.put()
 
-		self.post_json(
-			'/assignment/{}/invite'.format(self.assignment.key.id()),
-			data={'email': invited.email[0]})
+    self.post_json(
+      '/assignment/{}/invite'.format(self.assignment.key.id()),
+      data={'email': invited.email[0]})
 
-		self.assertEqual(inst.invited, [invited.key])
+    self.assertEqual(inst.invited, [invited.key])
 
-		# Check audit log
-		audit_logs = models.AuditLog.query().fetch()
-		self.assertEqual(len(audit_logs), 1)
-		log = audit_logs[0]
-		self.assertEqual(log.user, self.user.key)
-		self.assertEqual('Group.invite', log.event_type)
-		self.assertIn(invited.email[0], log.description)
+    # Check audit log
+    audit_logs = models.AuditLog.query().fetch()
+    self.assertEqual(len(audit_logs), 1)
+    log = audit_logs[0]
+    self.assertEqual(log.user, self.user.key)
+    self.assertEqual('Group.invite', log.event_type)
+    self.assertIn(invited.email[0], log.description)
 
-	def test_invite(self):
-		self.user = self.accounts['dummy_student2']
-		inst = self.get_basic_instance()
-		inst.put()
-		invited = self.accounts['dummy_student']
+  def test_invite(self):
+    self.user = self.accounts['dummy_student2']
+    inst = self.get_basic_instance()
+    inst.put()
+    invited = self.accounts['dummy_student']
 
-		self.post_json(
-			'/{}/{}/add_member'.format(self.name, inst.key.id()),
-			data={'email': invited.email[0]})
+    self.post_json(
+      '/{}/{}/add_member'.format(self.name, inst.key.id()),
+      data={'email': invited.email[0]})
 
-		self.assertEqual(inst.invited, [invited.key])
+    self.assertEqual(inst.invited, [invited.key])
 
-	def test_accept(self):
-		self.user = self.accounts['dummy_student']
-		inst = self.get_basic_instance()
-		inst.invited.append(self.user.key)
-		inst.put()
+  def test_accept(self):
+    self.user = self.accounts['dummy_student']
+    inst = self.get_basic_instance()
+    inst.invited.append(self.user.key)
+    inst.put()
 
-		self.post_json('/{}/{}/accept'.format(self.name, inst.key.id()))
+    self.post_json('/{}/{}/accept'.format(self.name, inst.key.id()))
 
-		self.assertEqual(inst.invited, [])
-		self.assertIn(self.user.key, inst.member)
+    self.assertEqual(inst.invited, [])
+    self.assertIn(self.user.key, inst.member)
 
-	def test_exit_invited(self):
-		self.user = self.accounts['dummy_student']
-		inst = self.get_basic_instance()
-		inst.invited.append(self.user.key)
-		inst.put()
+  def test_exit_invited(self):
+    self.user = self.accounts['dummy_student']
+    inst = self.get_basic_instance()
+    inst.invited.append(self.user.key)
+    inst.put()
 
-		self.post_json('/{}/{}/decline'.format(self.name, inst.key.id()))
+    self.post_json('/{}/{}/decline'.format(self.name, inst.key.id()))
 
-		self.assertEqual(inst.invited, [])
-		self.assertNotIn(self.user.key, inst.member)
+    self.assertEqual(inst.invited, [])
+    self.assertNotIn(self.user.key, inst.member)
 
-	def test_exit_member(self):
-		self.user = self.accounts['dummy_student']
-		inst = self.get_basic_instance()
-		inst.member.append(self.user.key)
-		inst.put()
+  def test_exit_member(self):
+    self.user = self.accounts['dummy_student']
+    inst = self.get_basic_instance()
+    inst.member.append(self.user.key)
+    inst.put()
 
-		self.post_json(
-			'/{}/{}/remove_member'.format(self.name, inst.key.id()),
-			data={'email': self.user.email[0]})
+    self.post_json(
+      '/{}/{}/remove_member'.format(self.name, inst.key.id()),
+      data={'email': self.user.email[0]})
 
-		self.assertNotIn(self.user.key, inst.member)
+    self.assertNotIn(self.user.key, inst.member)
 
-	def test_invite_someone_in_a_group(self):
-		self.user = self.accounts['dummy_student2']
-		inst = self.get_basic_instance()
-		inst.put()
+  def test_invite_someone_in_a_group(self):
+    self.user = self.accounts['dummy_student2']
+    inst = self.get_basic_instance()
+    inst.put()
 
-		# Place dummy_student in another group
-		invited = self.accounts['dummy_student']
-		self.model(
-			assignment=self.assignment.key,
-			member=[invited.key, self.accounts['dummy_staff'].key]
-		).put()
+    # Place dummy_student in another group
+    invited = self.accounts['dummy_student']
+    self.model(
+      assignment=self.assignment.key,
+      member=[invited.key, self.accounts['dummy_staff'].key]
+    ).put()
 
-		self.post_json(
-			'/{}/{}/add_member'.format(self.name, inst.key.id()),
-			data={'email': invited.email[0]})
+    self.post_json(
+      '/{}/{}/add_member'.format(self.name, inst.key.id()),
+      data={'email': invited.email[0]})
 
-		self.assertStatusCode(400)
-		self.assertEqual(inst.invited, [])
+    self.assertStatusCode(400)
+    self.assertEqual(inst.invited, [])
 
-	def test_remove_from_two_member_group(self):
-		self.user = self.accounts['dummy_student']
-		inst = self.model(assignment=self.assignment.key,
-		                  member=[self.user.key, self.accounts['dummy_student2'].key])
-		inst.put()
+  def test_remove_from_two_member_group(self):
+    self.user = self.accounts['dummy_student']
+    inst = self.model(assignment=self.assignment.key,
+                      member=[self.user.key, self.accounts['dummy_student2'].key])
+    inst.put()
 
-		self.post_json(
-			'/{}/{}/remove_member'.format(self.name, inst.key.id()),
-			data={'email': self.user.email[0]})
+    self.post_json(
+      '/{}/{}/remove_member'.format(self.name, inst.key.id()),
+      data={'email': self.user.email[0]})
 
-		self.assertStatusCode(200)
-		self.assertEqual(inst.key.get(), None)
+    self.assertStatusCode(200)
+    self.assertEqual(inst.key.get(), None)
 
-	def test_decline_invite_from_two_member_group(self):
-		self.user = self.accounts['dummy_student']
+  def test_decline_invite_from_two_member_group(self):
+    self.user = self.accounts['dummy_student']
 
-		members = [self.accounts['dummy_student2'].key]
-		inst = self.model(assignment=self.assignment.key, member=members,
-		                  invited=[self.user.key])
-		inst.put()
+    members = [self.accounts['dummy_student2'].key]
+    inst = self.model(assignment=self.assignment.key, member=members,
+                      invited=[self.user.key])
+    inst.put()
 
-		self.post_json(
-			'/{}/{}/decline'.format(self.name, inst.key.id()),
-			data={'email': self.user.email[0]})
+    self.post_json(
+      '/{}/{}/decline'.format(self.name, inst.key.id()),
+      data={'email': self.user.email[0]})
 
-		self.assertStatusCode(200)
-		self.assertEqual(inst.key.get(), None)
+    self.assertStatusCode(200)
+    self.assertEqual(inst.key.get(), None)
 
-	def test_create_two_entities(self):
-		pass # No creation
+  def test_create_two_entities(self):
+    pass # No creation
 
-	def test_entity_create_basic(self):
-		pass # No creation
+  def test_entity_create_basic(self):
+    pass # No creation

--- a/server/tests/unittests/test_group.py
+++ b/server/tests/unittests/test_group.py
@@ -16,8 +16,12 @@ PTest = PermissionsUnitTest.PTest
 COURSE_TESTS = [
     PTest("anon_get_group",
           "anon", "Group", "group1", "get", False),
+    PTest("anon_index_group",
+        "anon", "Group", "group1", "index", False),
     PTest("admin_get_group",
           "admin", "Group", "group1", "get", True),
+    PTest("admin_index_group",
+          "admin", "Group", "group1", "index", True),
 ]
 
 #pylint: disable=no-init, missing-docstring


### PR DESCRIPTION
The API used a field name of members while the model used a field name of member. Fixing this allows the autograder to query for group information as well. 