### PR TITLE
hide sensitive info from json

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -2124,4 +2124,3 @@ class AnalyticsAPI(APIResource):
         return (201, 'success', {
             'key': job.job_dump.key.id()
         })
-

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -80,6 +80,12 @@ class Base(ndb.Model):
         if self.key and (not fields or 'id' in fields):
             result['id'] = self.key.id()
 
+        # Protect sensitive fields
+        sensitive_fields = ['zip_file_url', 'grading_script_file']
+        for sensitive in sensitive_fields:
+            if sensitive in result:
+                result[sensitive] = ''
+
         for key, value in result.items():
             if isinstance(value, ndb.Key):
                 value = value.get()


### PR DESCRIPTION
Hide autograder fields from json responses. I thought this was already implemented but apparently not. 

This shouldn't break anything because ok sends the relevant information to the autograder - not the other way around. 