### PR TITLE
Bug/knrafto/optimize get course info

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ To run the server locally:
 
 ```bash
 $ source activate_server.sh 
+$ cd server
 $ bower install  # to install frontend CSS/JS libraries
 $ ./start_server
 ```
+
+The server will listen on http://localhost:8080.
 
 Deploying
 ---------

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -682,7 +682,7 @@ class UserAPI(APIResource):
         return obj.get_backups(data['assignment'], data['quantity'])
 
     def get_submissions(self, obj, user, data):
-        return [subm.submission for subm in obj.get_submissions(data['assignment'], data['quantity'])]
+        return obj.get_submissions(data['assignment'], data['quantity'])
 
     def merge_user(self, obj, user, data):
         """

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -286,18 +286,18 @@ class User(Base):
         @ndb.tasklet
         def assignment_info(assignment):
             group = self.group(assignment.key).get()
-            final_info, first_backup, first_submission = yield (
+            final_info, num_backups, num_submissions = yield (
                 final_submission_info(group, assignment),
-                self.backups(group, assignment.key).get_async(),
-                self.submissions(group, assignment.key).get_async())
+                self.backups(group, assignment.key).count_async(1),
+                self.submissions(group, assignment.key).count_async(1))
             raise ndb.Return({
                 'group': {
                     'group_info': group,
                     'invited': group and self.key in group.invited
                 },
                 'final': final_info,
-                'backups': first_backup is not None,
-                'submissions': first_submission is not None,
+                'backups': num_backups > 0,
+                'submissions': num_submissions,
                 'assignment': assignment
             })
 

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -195,100 +195,71 @@ class User(Base):
         if email in self.email and len(self.email) > 1:
             self.email.remove(email)
 
-    def get_final_submission(self, assignment_key):
-        """Get the current final submission for this user."""
+    def final_submission(self, group, assignment_key):
+        """A query for the final submission of a group and assignment."""
         if isinstance(assignment_key, Assignment):
             assignment_key = assignment_key.key
-        group = self.get_group(assignment_key)
         if group and self.key in group.member:
             return FinalSubmission.query(
                 FinalSubmission.assignment==assignment_key,
-                FinalSubmission.group==group.key).get()
+                FinalSubmission.group==group.key)
         else:
             return FinalSubmission.query(
                 FinalSubmission.assignment==assignment_key,
-                FinalSubmission.submitter==self.key).get()
+                FinalSubmission.submitter==self.key)
+
+    def get_final_submission(self, assignment_key):
+        """Get the current final submission for this user."""
+        group = self.get_group(assignment_key)
+        return self.final_submission(group, assignment_key).get()
 
     def _contains_files(self, backup):
         messages = backup.get_messages()
         if 'file_contents' in messages:
             return messages['file_contents']
 
-    def _get_backups_helper(self, assignment):
-        group = self.get_group(assignment)
+    def members(self, group):
+        """The members of a group. If group is None, then we are its only member."""
         if not group or self.key not in group.member:
-            members = [self.key]
+            return [self.key]
         else:
-            members = group.member
+            return group.member
 
-        all_backups = []
-        for member in members:
-            all_backups.append(Backup.query(
-                Backup.submitter == member,
-                Backup.assignment == assignment))
-
-        return all_backups
+    def backups(self, group, assignment):
+        """A query that fetches all backups for a group and assignment."""
+        members = self.members(group)
+        return Backup.query(
+            Backup.submitter.IN(members),
+            Backup.assignment == assignment
+        ).order(-Backup.server_time)
 
     def get_backups(self, assignment, num_backups=10):
-        queries = self._get_backups_helper(assignment)
-        backups = [query.fetch(num_backups) for query in queries]
-        all_backups = []
-        for results in backups:
-            for b in results:
-                all_backups.append(b)
-
-        all_backups.sort(lambda x, y: int(-5*(int(x.server_time > y.server_time) - 0.5)))
-
-        return all_backups[:num_backups]
-
-    def _get_submissions_helper(self, assignment):
         group = self.get_group(assignment)
-        if not group or self.key not in group.member:
-            members = [self.key]
-        else:
-            members = group.member
+        return self.backups(group, assignment).fetch(num_backups)
 
-        all_submissions = []
-        for member in members:
-            all_submissions.append(Submission.query(
-                Submission.submitter==member,
-                Submission.assignment==assignment))
-
-        return all_submissions
+    def submissions(self, group, assignment):
+        """A query that fetches all backups for a group and assignment."""
+        members = self.members(group)
+        return Submission.query(
+            Submission.submitter.IN(members),
+            Submission.assignment == assignment
+        ).order(-Backup.server_time)
 
     def get_submissions(self, assignment, num_submissions=10):
-        queries = self._get_submissions_helper(assignment)
+        group = self.get_group(assignment)
+        return self.submissions(group, assignment).fetch(num_submissions)
 
-        subms = [query.fetch() for query in queries]
-        all_subms = []
-        for results in subms:
-            for s in results:
-                all_subms.append(s)
-
-        def update(x):
-            b = x.backup.get()
-            b.submission = x
-            return b
-
-        all_subms = [update(x) for x in all_subms]
-        all_subms = [x for x in all_subms if x.assignment == assignment \
-                and self._contains_files(x)]
-
-        all_subms.sort(lambda x, y: int(-5*(int(x.server_time > y.server_time) - 0.5)))
-
-        return all_subms[:num_submissions]
-
-    get_num_submissions = make_num_counter(_get_submissions_helper)
-    get_num_backups = make_num_counter(_get_backups_helper)
-
-
-    def get_group(self, assignment_key):
-        """Return the group for this user for an assignment."""
+    def group(self, assignment_key):
+        """Return a query that fetches the group for this user for an assignment."""
         if isinstance(assignment_key, Assignment):
             assignment_key = assignment_key.key
         return Group.query(ndb.OR(Group.member==self.key,
                                   Group.invited==self.key),
-                           Group.assignment==assignment_key).get()
+                           Group.assignment==assignment_key)
+
+    def get_group(self, assignment_key):
+        """Return the group for this user for an assignment."""
+        return self.group(assignment_key).get()
 
     def get_course_info(self, course):
         if not course:
@@ -296,8 +267,10 @@ class User(Base):
 
         @ndb.tasklet
         def assignment_info(assignment):
-            group = self.get_group(assignment.key) # TODO: async
-            final_submission = self.get_final_submission(assignment.key) # TODO: async
+            group = self.group(assignment.key).get()
+            final_submission = self.final_submission(group, assignment.key).get() # TODO: async
+            has_backups = self.backups(group, assignment.key).get() is None # TODO: async
+            has_submissions = self.submissions(group, assignment.key).get() is None # TODO: async
             if final_submission:
                 submission = final_submission.submission.get() # TODO: async
                 backup = submission.backup.get() # TODO: async
@@ -311,8 +284,6 @@ class User(Base):
                     final_info['revision'] = revision
             else:
                 final_info = {}
-            has_backups = self.get_num_backups(assignment.key, 1) > 0 # TODO: async
-            has_submissions = self.get_num_submissions(assignment.key, 1) > 0 # TODO: async
             return {
                 'group': {
                     'group_info': group,

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -296,7 +296,7 @@ class User(Base):
 
         info = {'user': self}
         info['assignments'] = []
-        assignments = sorted(course.assignments)
+        assignments = course.assignments.order(-Assignment.due_date)
 
         for assignment in assignments:
             assign_info = {}

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -297,7 +297,7 @@ class User(Base):
                 },
                 'final': final_info,
                 'backups': num_backups > 0,
-                'submissions': num_submissions,
+                'submissions': num_submissions > 0,
                 'assignment': assignment
             })
 

--- a/server/app/seed/__init__.py
+++ b/server/app/seed/__init__.py
@@ -293,86 +293,84 @@ def seed():
     course.put()
 
     # Create a few assignments
-    assign = make_future_assignment(course, c)
-    assign.put()
-    assign2 = make_past_assignment(course, c)
-    assign2.put()
-    assignHW = make_hw_assignment(course, c)
-    assignHW.put()
+    assignments = []
+    for _ in range(4):
+        assignments += [
+            make_future_assignment(course, c),
+            make_past_assignment(course, c),
+            make_hw_assignment(course, c)
+        ]
 
-    # Create submissions
-    subms = []
+    for assign in assignments:
+        assign.put()
+        # Create submissions
+        subms = []
 
-    # Group submission
-    team1 = group_members[0:2]
-    g1 = make_group(assign, team1)
-    g1.put()
-
-
-    team2 = group_members[2:4]
-    g2 = make_invited_group(assign, team2)
-    g2.put()
-
-    team3 = group_members[4:6]
-    g3 = make_group(assign, team3)
-    g3.put()
+        # Group submission
+        team1 = group_members[0:2]
+        g1 = make_group(assign, team1)
+        g1.put()
 
 
-    # Have each member in the group submit one
-    for member in group_members:
-        subm = make_seed_submission(assign, member)
-        subm.put()
+        team2 = group_members[2:4]
+        g2 = make_invited_group(assign, team2)
+        g2.put()
 
-    # for member in group_members:
-    #     subm = make_seed_scheme_submission(assign2, member)
-    #     subm.put()
-
-    group1_subm = make_seed_submission(assign, group_members[1])
-    group1_subm.put()
-    # Make team 1's submission final and score it.
-    final = make_final_with_group(group1_subm, assign, group_members[1], g1)
-    score_seed_submission(final, 2, "Nice job, group 1!", staff[8])
-    subms.append(group1_subm)
-
-    group3_subm = make_seed_submission(assign, group_members[5])
-    group3_subm.put()
-    # Make team 1's submission final and score it.
-    final3 = make_final_with_group(group3_subm, assign, group_members[5], g3)
-    score_seed_submission(final3, 1, "Awesome job, group 3!", staff[8])
-    subms.append(group3_subm)
-
-    # Make this one be a final submission though.
-    # subm = make_seed_submission(assign, group_members[1], True)
-    # subm.put()
-    # subms.append(subm)
+        team3 = group_members[4:6]
+        g3 = make_group(assign, team3)
+        g3.put()
 
 
-    # scheme final
-    # subm = make_seed_scheme_submission(assign2, group_members[1], True)
-    # subm.put()
+        # Have each member in the group submit one
+        for member in group_members:
+            subm = make_seed_submission(assign, member)
+            subm.put()
 
-    # Now create indiviual submission
-    for i in range(9):
-        subm = make_seed_submission(assign, students[i])
-        subm.put()
-        #subms.append(subm)
+        # for member in group_members:
+        #     subm = make_seed_scheme_submission(assign2, member)
+        #     subm.put()
 
-        subm = make_seed_submission(assign, students[i], True)
-        subm.put()
-        subms.append(subm)
+        group1_subm = make_seed_submission(assign, group_members[1])
+        group1_subm.put()
+        # Make team 1's submission final and score it.
+        final = make_final_with_group(group1_subm, assign, group_members[1], g1)
+        score_seed_submission(final, 2, "Nice job, group 1!", staff[8])
+        subms.append(group1_subm)
 
-        # Make each individual submission final and score it.
-        final = make_final(subm, assign, students[i])
-        score_seed_submission(final, i, "Good job, student %s" % str(i), staff[i])
+        group3_subm = make_seed_submission(assign, group_members[5])
+        group3_subm.put()
+        # Make team 1's submission final and score it.
+        final3 = make_final_with_group(group3_subm, assign, group_members[5], g3)
+        score_seed_submission(final3, 1, "Awesome job, group 3!", staff[8])
+        subms.append(group3_subm)
+
+        # Make this one be a final submission though.
+        # subm = make_seed_submission(assign, group_members[1], True)
+        # subm.put()
+        # subms.append(subm)
 
 
-    # Seed a queue. This should be auto-generated.
-    make_queue(assign, subms[:len(subms)//2], c)
-    make_queue(assign, subms[len(subms)//2:], k)
+        # scheme final
+        # subm = make_seed_scheme_submission(assign2, group_members[1], True)
+        # subm.put()
 
-    utils.add_to_grading_queues(assign.key)
+        # Now create indiviual submission
+        for i in range(9):
+            subm = make_seed_submission(assign, students[i])
+            subm.put()
+            #subms.append(subm)
+
+            subm = make_seed_submission(assign, students[i], True)
+            subm.put()
+            subms.append(subm)
+
+            # Make each individual submission final and score it.
+            final = make_final(subm, assign, students[i])
+            score_seed_submission(final, i, "Good job, student %s" % str(i), staff[i])
 
 
+        # Seed a queue. This should be auto-generated.
+        make_queue(assign, subms[:len(subms)//2], c)
+        make_queue(assign, subms[len(subms)//2:], k)
 
-
-
+        utils.add_to_grading_queues(assign.key)

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -334,10 +334,10 @@ def add_to_grading_queues(assign_key, cursor=None, num_updated=0):
             continue
         queues.sort(key=lambda x: len(x.submissions))
 
-        subm = user.get_selected_submission(assign_key, keys_only=True)
-        if subm and user.is_final_submission(subm, assign_key):
-            subm_got = subm.get()
-            if subm_got.get_messages().get('file_contents'):
+        final_subm = user.get_final_submission(assign_key)
+        if final_subm:
+            subm = final_subm.submission.get()
+            if final_subm.backup.get_messages().get('file_contents'):
                 queues[0].submissions.append(subm)
                 seen.add(user.key.id())
                 to_put += 1

--- a/server/index.yaml
+++ b/server/index.yaml
@@ -48,6 +48,13 @@ indexes:
 
 - kind: Backupv2
   properties:
+  - name: assignment
+  - name: submitter
+  - name: server_time
+    direction: desc
+
+- kind: Backupv2
+  properties:
   - name: messages.kind
   - name: submitter
   - name: created

--- a/server/index.yaml
+++ b/server/index.yaml
@@ -27,6 +27,12 @@ indexes:
   - name: created
     direction: desc
 
+- kind: Assignmentv2
+  properties:
+  - name: course
+  - name: due_date
+    direction: desc
+
 - kind: Backupv2
   properties:
   - name: assignment

--- a/server/tests/integration/test_api_user.py
+++ b/server/tests/integration/test_api_user.py
@@ -180,7 +180,7 @@ class UserAPITest(APIBaseTestCase):
 			'assignment': self._assign.key,
 			'quantity': 5
 		})
-		self.assertEqual(len(subms), 0)  # because the 1 submission in the DB doesn't have files
+		self.assertEqual(len(subms), 1)
 
 		for subm in subms:
 			self.assertTrue(isinstance(subm, models.Submission))

--- a/server/tests/regression/test_models.py
+++ b/server/tests/regression/test_models.py
@@ -62,24 +62,24 @@ class ModelsTestCase(BaseTestCase):
 		self.assertEqual(user._contains_files(backup_with), 'HUEHUE')
 		self.assertEqual(user._contains_files(backup_without), None)
 
-	def test_get_backups_helper_in_group(self):
+	def test_get_backups_in_group(self):
 		""" Test self not in group """
 		user = models.User(email=['yo@yo.com']).put().get()
 		user.get_group = MagicMock(
 			return_value=MagicMock(
 				member=[user.key]))
-		user._get_backups_helper(None)
+		user.get_backups(None)
 
 		user.get_group.assert_called_with(None)
 		assert user.key in user.get_group(None).member
 
-	def test_get_submissions_helper_in_group(self):
+	def test_get_submissions_in_group(self):
 		""" Test self not in group """
 		user = models.User(email=['yo@yo.com']).put().get()
 		user.get_group = MagicMock(
 			return_value=MagicMock(
 				member=[user.key]))
-		user._get_submissions_helper(None)
+		user.get_submissions(None)
 
 		user.get_group.assert_called_with(None)
 		assert user.key in user.get_group(None).member


### PR DESCRIPTION
Tried to simplify some queries and parallelize using ndb tasklets. ~2x faster, ~2x less DB queries. Related to #575.

The local server now has a lot more assignments and submissions so I could get a good benchmark.

Point of contention: All submissions are now treated as submissions, rather than only submissions with files. I'm not clear on when a submissions wouldn't have files, or what happens when they don't. But it doesn't simplify things a whole lot.

## Benchmarks
### Cold cache
#### Before
<img width="1155" alt="before cold" src="https://cloud.githubusercontent.com/assets/2042019/9648659/a8b4852c-519f-11e5-883d-c7e237db3b14.png">
#### After
<img width="1140" alt="after cold" src="https://cloud.githubusercontent.com/assets/2042019/9648658/a8b367e6-519f-11e5-9a18-2fa2e39f81cd.png">
### Warm cache
#### Before
<img width="1145" alt="before warm" src="https://cloud.githubusercontent.com/assets/2042019/9648660/a8b49274-519f-11e5-9b19-1199cf3eb72f.png">
#### After
<img width="1159" alt="after warm" src="https://cloud.githubusercontent.com/assets/2042019/9648657/a8b29b22-519f-11e5-8f16-b239a8a72e6b.png">
