### PR TITLE
Zip encoding

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1369,8 +1369,7 @@ class SearchAPI(APIResource):
         self.check_permissions(user, data)
 
         filename = make_zip_filename(user, datetime.datetime.now())
-        deferred.defer(subms_to_gcs, SearchAPI, SubmissionAPI(),
-                       models.Submission, filename, data)
+        deferred.defer(subms_to_gcs, SearchAPI, SubmissionAPI(), filename, data)
         return [filename]
 
 

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1030,13 +1030,6 @@ class SubmissionAPI(APIResource):
         if 'submit' in file_contents:
             del file_contents['submit']
 
-        # Need to encode every file before it is.
-        for key in file_contents.keys():
-            try:
-                file_contents[key] = str(file_contents[key]).encode('utf-8')
-            except:  # pragma: no cover
-                pass
-
         json_pretty = dict(sort_keys=True, indent=4, separators=(',', ': '))
         group_files = backup_group_file(obj, json_pretty)
         if group_files:

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1379,11 +1379,10 @@ class SearchAPI(APIResource):
         """ Sets up zip write to GCS """
         self.check_permissions(user, data)
 
-        now = datetime.datetime.now()
+        filename = make_zip_filename(user, datetime.datetime.now())
         deferred.defer(subms_to_gcs, SearchAPI, SubmissionAPI(),
-                       models.Submission, user, data, now)
-
-        return [make_zip_filename(user, now)]
+                       models.Submission, filename, data)
+        return [filename]
 
 
     @staticmethod

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1093,7 +1093,7 @@ class SubmissionAPI(APIResource):
 
         for key in file_contents.keys():
             try:
-                file_contents[key] = str(file_contents[key]).encode('utf-8')
+                file_contents[key] = unicode(file_contents[key]).encode('utf-8')
             except:  # pragma: no cover
                 pass
 

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -561,10 +561,10 @@ def scores_to_gcs(assignment, user):
     create_gcs_file(csv_filename, csv_contents, 'text/csv')
 
 
-def add_subm_to_zip(subm, Submission, zipfile, submission):
+def add_subm_to_zip(subm, zipfile, submission):
     """ Adds submission contents to a zipfile in-place, returns zipfile """
     try:
-        if isinstance(submission, FinalSubmission):
+        if isinstance(submission, ModelProxy.FinalSubmission):
             # Get the actual submission
             submission = submission.submission.get()
         backup = submission.backup.get()
@@ -614,7 +614,7 @@ def make_zip_filename(user, now):
     return filename+'.zip'
 
 
-def subms_to_gcs(SearchAPI, subm, Submission, filename, data):
+def subms_to_gcs(SearchAPI, subm, filename, data):
     """Writes all submissions for a given search query to a GCS zip file."""
     query = SearchAPI.querify(data['query'])
     gcs_file = gcs.open(filename, 'w',
@@ -623,7 +623,7 @@ def subms_to_gcs(SearchAPI, subm, Submission, filename, data):
     with contextlib.closing(gcs_file) as f:
         with zf.ZipFile(f, 'w') as zipfile:
             for result in query:
-                add_subm_to_zip(subm, Submission, zipfile, result)
+                add_subm_to_zip(subm, zipfile, result)
     logging.info("Exported submissions to " + filename)
 
 def submit_to_ag(assignment, messages, submitter):

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -120,7 +120,7 @@ def add_to_zip(zipfile, file_contents, dir=''):
     Adds files to a given zip file. Uses specified dir to store files.
     """
     for filename, contents in file_contents.items():
-        zipfile.writestr(join(dir, filename), contents)
+        zipfile.writestr(join(dir, filename).encode('utf-8'), contents.encode('utf-8'))
     return zipfile
 
 def create_csv_content(content):

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -5,6 +5,7 @@ Utility functions used by API and other services
 # pylint: disable=no-member
 
 import collections
+import contextlib
 import logging
 import datetime
 import itertools

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -561,12 +561,14 @@ def scores_to_gcs(assignment, user):
     create_gcs_file(csv_filename, csv_contents, 'text/csv')
 
 
-def add_subm_to_zip(subm, Submission, zipfile, result):
+def add_subm_to_zip(subm, Submission, zipfile, submission):
     """ Adds submission contents to a zipfile in-place, returns zipfile """
     try:
-        if isinstance(result, Submission):
-            result = result.backup.get()
-        name, file_contents = subm.data_for_zip(result)
+        if isinstance(submission, FinalSubmission):
+            # Get the actual submission
+            submission = submission.submission.get()
+        backup = submission.backup.get()
+        name, file_contents = subm.data_for_zip(backup)
         return add_to_zip(zipfile, file_contents, name)
     except BadValueError as e:
         if str(e) != 'Submission has no contents to download':

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -125,11 +125,10 @@ def add_to_zip(zipfile, files, dir=''):
     :param dir: (str) directory to place files in. Both this and the filename
         will be utf-8 encoded.
     """
-    for filename, contents in files.items():
-        zipfile.writestr(
-            # TODO(knrafto) not sure if zip paths should be utf-8
-            path.join(dir, filename).encode('utf-8'),
-            str(contents).encode('utf-8'))
+    for filename, contents in files.iteritems():
+        # The Python 2.7 zipfile packages encodes filenames as UTF-8, but
+        # does not encode the contents.
+        zipfile.writestr(path.join(dir, filename), unicode(contents).encode('utf-8'))
     return zipfile
 
 def create_csv_content(content):

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -9,7 +9,7 @@ import contextlib
 import logging
 import datetime
 import itertools
-from os.path import join
+from os import path
 from app import constants
 import requests
 
@@ -115,12 +115,21 @@ def finish_zip(zipfile_str, zipfile):
     return zipfile_str.getvalue()
 
 
-def add_to_zip(zipfile, file_contents, dir=''):
+def add_to_zip(zipfile, files, dir=''):
     """
     Adds files to a given zip file. Uses specified dir to store files.
+
+    :param zipfile: (ZipFile) zip archive to be extended
+    :param files: (dict) map from filenames (str) to file contents.
+        File contents will be encoded into a utf-8 text file.
+    :param dir: (str) directory to place files in. Both this and the filename
+        will be utf-8 encoded.
     """
-    for filename, contents in file_contents.items():
-        zipfile.writestr(join(dir, filename).encode('utf-8'), contents.encode('utf-8'))
+    for filename, contents in files.items():
+        zipfile.writestr(
+            # TODO(knrafto) not sure if zip paths should be utf-8
+            path.join(dir, filename).encode('utf-8'),
+            str(contents).encode('utf-8'))
     return zipfile
 
 def create_csv_content(content):

--- a/server/static/js/admin/controllers.js
+++ b/server/static/js/admin/controllers.js
@@ -486,7 +486,6 @@ app.controller("SubmissionListCtrl", ['$scope', '$stateParams', '$window', 'Sear
       }, function(response) {
         $scope.submissions = response.data.results;
         $scope.more = response.data.more;
-        $scope.search_query = encodeURIComponent(response.data.query);
         if (response.data.more) {
           $scope.totalItems = $scope.currentPage * $scope.itemsPerPage + 1;
         } else {

--- a/server/static/partials/admin/submission.list.html
+++ b/server/static/partials/admin/submission.list.html
@@ -32,9 +32,9 @@
       <h3 class="box-title" ng-if="submissions.length > 0">All Submissions</h3>
       <h4 class="box-title" ng-if="submissions.length == 0" >No Submissions</h3>
       <div class="box-tools" style="float:right;">
-          <button ng-click="download_zip(search_query, 'True', course.id)" class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" style="margin-right:5px"> <i class="fa fa-download"></i>  Download All</button>
-          <button ng-click="download_zip(search_query, 'False', course.id)" class="btn btn-primary btn-sm" ng-if="more || currentPage != 1"> <i class="fa fa-download"></i>  Download Page</button>
-          <button ng-click="download_zip(search_query, 'True', course.id)" class="btn btn-primary btn-sm" ng-if="!more && currentPage == 1"> <i class="fa fa-download"></i>  Download</button>
+          <button ng-click="download_zip(query.string, 'True', course.id)" class="btn btn-primary btn-sm" ng-if="more || currentPage != 1" style="margin-right:5px"> <i class="fa fa-download"></i>  Download All</button>
+          <button ng-click="download_zip(query.string, 'False', course.id)" class="btn btn-primary btn-sm" ng-if="more || currentPage != 1"> <i class="fa fa-download"></i>  Download Page</button>
+          <button ng-click="download_zip(query.string, 'True', course.id)" class="btn btn-primary btn-sm" ng-if="!more && currentPage == 1"> <i class="fa fa-download"></i>  Download</button>
       </div>
     </div>
     <!-- /.box-header -->

--- a/server/tests/integration/test_api_submission.py
+++ b/server/tests/integration/test_api_submission.py
@@ -97,7 +97,7 @@ class SubmissionAPITest(APIBaseTestCase):
 			get_messages=lambda: {'file_contents': info},
 			assignment=self._assign.key,
 			to_json=lambda: {}))
-		self.assertEqual(info['gup.py'], '1')
+		self.assertEqual(info['gup.py'], 1)
 
 	def test_zip(self):
 		""" Tests that zip does not crash """

--- a/server/tests/integration/test_utils.py
+++ b/server/tests/integration/test_utils.py
@@ -63,7 +63,7 @@ class UtilsTestCase(APIBaseTestCase):
 		for result in results:
 			subm = api.SubmissionAPI()
 			zipfile_str, zipfile = utils.start_zip()
-			zipfile = utils.add_subm_to_zip(subm, result.__class__, zipfile, result)
+			zipfile = utils.add_subm_to_zip(subm, zipfile, result)
 			assert zipfile is None or len(zipfile.infolist()) > 0
 
 	def test_start_zip_basic(self):


### PR DESCRIPTION
Fixes #597. We pass [zipfile](https://docs.python.org/3/library/zipfile.html) the Cloudstorage file stream so we don't hold all the contents in memory.

Tried it on Hog and successfully downloaded the zip (98M). Extracted and got some duplicate files (a lot, actually). They look like this:
```
replace ****@berkeley-edu-2015-09-10_05:50:37-246979/group_members_****.json? [y]es, [n]o, [A]ll, [N]one, [r]ename: 
```