### PR TITLE
Fix broken links in assignments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 
 To install:
 * Clone this repo
-* Install [Google App Engine SDK](https://developers.google.com/appengine/downloads) and add it to your `$PATH`. You can do `brew install google-app-engine` on a mac.
+* Install [Google App Engine SDK for Python](https://developers.google.com/appengine/downloads) and add it to your `$PATH`. You can do `brew install google-app-engine` on a mac.
 * `export GAE_SDK=<location of unzipped GAE SDK>`
   - For brew, this location should be in /usr/local/Cellar/google-app-engine/1.9.X/share/google-app-engine.
   - Some files that should be present when running `ls $GAE_SDK` are `dev_appserver.py` and `api_server.py`.
@@ -102,7 +102,7 @@ Autograding
 Projects using ok.py
 --------------------
 
-[CS61A](cs61a.org) uses ok.py for all assignments.
+[CS61A](http://cs61a.org) uses ok.py for all assignments.
 
 Developer Guidelines
 --------------------

--- a/server/app/seed/__init__.py
+++ b/server/app/seed/__init__.py
@@ -42,6 +42,7 @@ def seed():
             max_group_size=4,
             due_date=date,
             lock_date=date,
+            url='cs61a.org/proj/hog',
             )
 
     # Will reject all scheme submissions

--- a/server/static/js/student/controllers.js
+++ b/server/static/js/student/controllers.js
@@ -452,6 +452,14 @@ app.controller("AssignmentDashController", ['$scope', '$window', '$state',  '$st
         return assignment
       }
 
+      $scope.makeAbsoluteURL = function makeAbsoluteURL(url) {
+        if (url.indexOf("http") == 0) {
+          return url
+        } else {
+          return "http://" + url
+        }
+      }
+
         $scope.openDetails = function openDetails(assign) {
             $scope.currGroup = assign.group
             $scope.currAssign = assign

--- a/server/static/partials/student/assignment.detail.html
+++ b/server/static/partials/student/assignment.detail.html
@@ -10,8 +10,13 @@
             <p class="blob-status" ng-if="assign.final.final_submission &&  assign.final.final_submission.revision"> Revision submitted </p>
             <h2 class="blob-title ng-binding">{{ assign.assignment.display_name }}</h2>
 
-            <p class="blob-shiftcopy blob-copy ng-binding"><span class="icon-clock"></span>due
-                {{ ::assign.assignment.due_date | amCalendar }}<br><a style="margin-left:-20px" ng-show="{{ assign.assignment.url.length > 0 }}" href="{{ assign.assignment.url }}"><i class="fa fa-link"></i> {{ assign.assignment.url }}</a></p>
+            <p class="blob-shiftcopy blob-copy ng-binding">
+                <span class="icon-clock"></span>due {{ ::assign.assignment.due_date | amCalendar }}<br>
+                <a style="margin-left:-20px" ng-show="{{ assign.assignment.url.length > 0 }}"
+                   href="{{ makeAbsoluteURL(assign.assignment.url) }}">
+                    <i class="fa fa-link"></i> {{ assign.assignment.url }}
+                </a>
+            </p>
             <p class="blob-copy" ng-if="assign.final.final_submission">
                 <a ng-hide="assign.final.submission.score.length > 0"
                    ui-sref='submission.detail({courseId: courseId, submissionId:assign.final.backup.id})'


### PR DESCRIPTION
Some links are broken when they are supposed to be external links but are instead interpreted as relative links. For instance on the most recent homework, the link in the assignment detail (shown below) is interpreted as going to `https://ok-server.appspot.com/cs61a.org/hw/hw08`, where it should go to `http://cs61a.org/hw/hw08` instead.

![ok-broken-link](https://cloud.githubusercontent.com/assets/1523594/10871422/4ac13ae8-809b-11e5-93bb-c6764ad379ea.png)

To fix this, I just added a function to check if a url string starts with `http`, and if it does, it is already absolute, but if not, `http://` is added so that the link becomes absolute. I also made some small changes to fix a broken link in the README with the same relative/absolute problem and specify that the Google App Engine SDK to download is for Python.