### PR TITLE
Fix submission score link styling

### DIFF
--- a/server/static/partials/student/assignment.dash.html
+++ b/server/static/partials/student/assignment.dash.html
@@ -25,12 +25,14 @@
                class="link view-submission">
               Submission ({{ assign.final.backup.created | amCalendar }}) &raquo;
             </a><br>
-            <div ng-repeat="score in assign.final.submission.score">
-              <a ng-hide="score.tag == 'autograder'"
-                 ng-click="showComposition(score, assign.final.backup.id)"
-                 class="link view-submission">{{ score.tag }}: {{ score.score }} &raquo;</a></p>
-              </a>
-            </div>
+          </p>
+          <div ng-repeat="score in assign.final.submission.score">
+            <p><a ng-hide="score.tag == 'autograder'"
+               ng-click="showComposition(score, assign.final.backup.id)"
+               class="link view-submission"
+               href="javascript:void(0)">{{ score.tag }}: {{ score.score }} &raquo;</a>
+            </a></p>
+          </div>
         </div>
         <div class="blob-action" ng-click="openDetails(assign)">View
           Details<span class="{{ assign.assignment.active || assign.assignment.revision ? 'white' : 'dark' }} arrow right"></span></div>

--- a/server/static/student/styles/courses.css
+++ b/server/static/student/styles/courses.css
@@ -5,12 +5,15 @@ h1,h2,h3,h4,h5,h6 {
 p, a, li, span:not([class^="hljs-"]) {
     font-family:'Roboto';
 }
-a, a:hover {
+a, a:hover, a:focus {
     text-decoration:inherit;
     font-size:inherit;
     font-weight:inherit;
     color:inherit;
     float:none;
+}
+a:focus {
+    outline: 0;
 }
     p a {       border-bottom:1px dotted #666 }
     p a:hover { border-bottom:1px solid #666 }


### PR DESCRIPTION
I added an underline and a pointer cursor to the submission score links to make it more obvious how to see submission feedback. It turns out that if a link element is missing the `href` attribute, it doesn't change the cursor, but if it has a `href` it will change it, so I added a javascript `href` that does nothing to get the cursor to behave properly. Also, Angular doesn't like block elements within paragraph tags, so I had to remove the div from the original paragraph tag to get it to be positioned correctly.

Here's the end result:

![ok-py-submission-links](https://cloud.githubusercontent.com/assets/1523594/10871371/eec68d16-8099-11e5-9927-6dcb71449223.png)
