### PR TITLE
Add Revision ID and Submission ID to grade export

### DIFF
--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -152,9 +152,9 @@ def create_csv_content(content):
 def data_for_scores(assignment, user):
     """
     Returns a tuple of two values a list of lists of score info for assignment.
-    Format: [['STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG']]
+    Format: [['STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG', 'SUBM_ID', 'REVISION_ID']]
     """
-    content = [['STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG']]
+    content = [['STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG', 'SUBM_ID', 'REVISION_ID']]
     course = assignment.course.get()
     groups = ModelProxy.Group.lookup_by_assignment(assignment)
     seen_members = set()
@@ -373,7 +373,6 @@ def assign_staff_to_queues(assignment_key, staff_list):
         subms = ModelProxy.FinalSubmission.query(
             ModelProxy.FinalSubmission.assignment == assignment_key
         ).fetch()
-
         queues = []
 
         for instr in staff_list:

--- a/server/tests/regression/test_models.py
+++ b/server/tests/regression/test_models.py
@@ -114,7 +114,7 @@ class ModelsTestCase(BaseTestCase):
         user = models.User(email=['yo@yo.com']).put().get()
         self.assertEqual(
             user.scores_for_assignment(assign),
-            ([[user.email[0], 0, None, None, None]], False))
+            ([[user.email[0], 0, None, None, None, None, None]], False))
 
     def test_scores_forassign_w_fs_wo_scores(self):
         """Tests that fs scores are loaded"""
@@ -131,23 +131,30 @@ class ModelsTestCase(BaseTestCase):
         self.assertNotEqual(user.get_final_submission(assign), None)
         self.assertFalse(user.scores_for_assignment(assign.get())[1])
 
-    def test_scores_forassign_w_fs_w_scores(self):
+    def test_scores_forassign_w_fs_w_rev_scores(self):
         """Tests that fs scores are loaded"""
         assign = models.Assignment().put()
         user = models.User(email=['yo@yo.com']).put()
         backup = models.Backup(submitter=user, assignment=assign).put()
-        score = models.Score(score=10, grader=user)
+        score = models.Score(score=10, grader=user, message="Nice!")
         subm = models.Submission(
             backup=backup,
             score=[score]).put()
-        models.FinalSubmission(
+        revision = models.Submission(
+            backup=backup).put()
+        fs = models.FinalSubmission(
             submitter=user,
             assignment=assign,
-            submission=subm).put()
+            submission=subm,
+            revision=revision).put()
 
         user = user.get()
         self.assertNotEqual(user.get_final_submission(assign), None)
-        self.assertTrue(user.scores_for_assignment(assign.get())[1])
+        scores_out = user.scores_for_assignment(assign.get())
+        self.assertTrue(len(scores_out[0]) == 1)
+        self.assertTrue(len(scores_out[0][0]) == 7)
+        self.assertEqual(scores_out[0][0][5], subm.id())
+        self.assertEqual(scores_out[0][0][6], revision.id())
 
     ##########
     # Course #


### PR DESCRIPTION
Grade Export now includes the submission ID and revision ID

(this is the actual ID of the submission, not the backup) 
