### PR TITLE
Auto Promotion of Backups

### DIFF
--- a/server/app/models.py
+++ b/server/app/models.py
@@ -763,7 +763,7 @@ class Submission(Base):
                 raise ValueError("Cannot flag submission that is past due date")
             return final.put()
         else:
-            if utils.normalize_to_utc(self.server_time) < utils.normalize_to_utc(assignment.due_date):
+            if utils.normalize_to_utc(self.server_time) < utils.normalize_to_utc(assignment.lock_date):
                 group = self.submitter.get().get_group(self.assignment)
                 final = FinalSubmission(
                     assignment=self.assignment, submission=self.key,
@@ -771,7 +771,7 @@ class Submission(Base):
                 if group:
                     final.group = group.key
                 return final.put()
-        raise ValueError("Cannot flag submission that is past due date")
+        raise ValueError("Cannot flag submissions that are past due date")
 
     def resubmit(self, user_key):
         """

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -747,6 +747,7 @@ class Submission(Base):
         """Create or update a final submission."""
         final = self.get_final()
         assignment = self.assignment.get()
+        backup = self.backup.get()
         if final:
             if assignment.revision:
                 # Follow resubmssion procedure
@@ -763,9 +764,9 @@ class Submission(Base):
             return final.put()
         else:
             logging.info("Attempting to mark as final")
-            logging.info(self.server_time)
+            logging.info(backup.server_time)
             logging.info(assignment.lock_date)
-            if utils.normalize_to_utc(self.server_time) < utils.normalize_to_utc(assignment.lock_date):
+            if utils.normalize_to_utc(backup.server_time) < utils.normalize_to_utc(assignment.lock_date):
                 group = self.submitter.get().get_group(self.assignment)
                 final = FinalSubmission(
                     assignment=self.assignment, submission=self.key)

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -754,14 +754,17 @@ class Submission(Base):
                 self.is_revision = True
                 self.put()
             elif datetime.datetime.now(pytz.utc) > utils.normalize_to_utc(assignment.lock_date):
-                return ValueError("Cannot change submission after due date")
+                raise ValueError("Cannot change submission after due date")
             elif utils.normalize_to_utc(self.server_time) <= utils.normalize_to_utc(assignment.lock_date):
                 final.submitter = self.submitter
                 final.submission = self.key
             else:
-                return ValueError("Cannot flag submission that is past due date")
+                raise ValueError("Cannot flag submission that is past due date")
             return final.put()
         else:
+            logging.info("Attempting to mark as final")
+            logging.info(self.server_time)
+            logging.info(assignment.lock_date)
             if utils.normalize_to_utc(self.server_time) < utils.normalize_to_utc(assignment.lock_date):
                 group = self.submitter.get().get_group(self.assignment)
                 final = FinalSubmission(
@@ -769,7 +772,7 @@ class Submission(Base):
                 if group:
                     final.group = group.key
                 return final.put()
-        return ValueError("Cannot flag submission that is past due date")
+        raise ValueError("Cannot flag submission that is past due date")
 
     def resubmit(self, user_key):
         """

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -763,12 +763,11 @@ class Submission(Base):
                 raise ValueError("Cannot flag submission that is past due date")
             return final.put()
         else:
-            if utils.normalize_to_utc(self.server_time) < utils.normalize_to_utc(assignment.lock_date):
+            if utils.normalize_to_utc(self.server_time) < utils.normalize_to_utc(assignment.due_date):
                 group = self.submitter.get().get_group(self.assignment)
                 final = FinalSubmission(
                     assignment=self.assignment, submission=self.key,
                     submitter=backup.submitter)
-                logging.info(final)
                 if group:
                     final.group = group.key
                 return final.put()

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -763,13 +763,12 @@ class Submission(Base):
                 raise ValueError("Cannot flag submission that is past due date")
             return final.put()
         else:
-            logging.info("Attempting to mark as final")
-            logging.info(backup.server_time)
-            logging.info(assignment.lock_date)
-            if utils.normalize_to_utc(backup.server_time) < utils.normalize_to_utc(assignment.lock_date):
+            if utils.normalize_to_utc(self.server_time) < utils.normalize_to_utc(assignment.lock_date):
                 group = self.submitter.get().get_group(self.assignment)
                 final = FinalSubmission(
-                    assignment=self.assignment, submission=self.key)
+                    assignment=self.assignment, submission=self.key,
+                    submitter=backup.submitter)
+                logging.info(final)
                 if group:
                     final.group = group.key
                 return final.put()

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -224,7 +224,8 @@ class User(Base):
             return group.member
 
     def backups(self, group, assignment):
-        """A query that fetches all backups for a group and assignment."""
+        """A query that fetches all backups for a group and assignment
+            (ordered by recency with the most recent backup first)."""
         members = self.members(group)
         return Backup.query(
             Backup.submitter.IN(members),

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -696,9 +696,12 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
         fs = student.get_final_submission(assignment)
         if not fs:
             recent_bcks = student.get_backups(assignment.key, 1)
+            # TODO: Also get submissions that weren't marked as final for some reason
             if len(recent_bcks) > 0:
                 try:
-                    new_sub = force_promote_backup(recent_bcks[0].key.id())
+                    # TODO: Get a bunch of backups and choose to closest to due date
+                    closest_backup = recent_bcks[0]
+                    new_sub = force_promote_backup(closest_backup.key.id())
                     newly_created_fs.append(new_sub.id())
                 except ValueError as e:
                     error_msg = "{email} only had backups past the due date".format(email=student.email[0])

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -691,7 +691,7 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
         ModelProxy.Participant.course == assignment.course,
         ModelProxy.Participant.role == STUDENT_ROLE))
 
-    new_submission = []
+    new_submissions = {}
     for participant in enrollment:
         student = participant.user.get()
         fs = student.get_final_submission(assignment.key)
@@ -704,11 +704,12 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
             # TODO: Also get submissions that weren't marked as final for some reason
             if chosen_backup:
                 new_fsub = force_promote_backup(chosen_backup.key.id())
-                new_submission.append(new_fsub.submission.id())
+                new_subm = new_fsub.get().submission
+                new_submissions[new_subm.id()] = new_subm.get().backup.id()
                 logging.info("Promoted backup for {}".format(student.email[0]))
 
     if autograde:
-        return autograde_subms(assignment, user, data, new_submission)
+        return autograde_subms(assignment, user, data, new_submissions)
 
 
 def force_promote_backup(backup_id):

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -697,7 +697,7 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
         if not fs:
             backup_q = student.backups(group, assignment)
             elgible_backups = backup_q.filter(Backup.server_time <= assignment.due_date)
-            chosen_backup = elgible_backups.order(-Backup.server_time).get()
+            chosen_backup = elgible_backups.get()
 
             # TODO: Also get submissions that weren't marked as final for some reason
             if chosen_backup:

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -701,14 +701,8 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
 
             # TODO: Also get submissions that weren't marked as final for some reason
             if chosen_backup:
-                try:
-                    # TODO: Get a bunch of backups and choose to closest to due date
-                    new_sub = force_promote_backup(chosen_backup.key.id())
-                    newly_created_fs.append(new_sub.id())
-                except ValueError as e:
-                    error_msg = "{email} only had backups past the due date".format(email=student.email[0])
-                    logging.info(error_msg)
-                    continue
+                new_sub = force_promote_backup(chosen_backup.key.id())
+                newly_created_fs.append(new_sub.id())
 
     if autograde:
         return autograde_subms(assignment, user, data, newly_created_fs)

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -701,7 +701,8 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
                     new_sub = force_promote_backup(recent_bcks[0].key.id())
                     newly_created_fs.append(new_sub.id())
                 except ValueError as e:
-                    logging.error(e) # For invalid submissions
+                    error_msg = "{email} only had backups past the due date".format(email=student.email[0])
+                    logging.info(error_msg)
                     continue
 
     if autograde:

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -669,7 +669,8 @@ def autograde_subms(assignment, user, data, subm_ids, priority="default"):
         # TODO: Contact staff (via email)
       return {'status_url': AUTOGRADER_URL+'/rq', 'length': str(len(subm_ids))}
     else:
-      raise BadValueError('The autograder the rejected your request')
+      error_message = 'The autograder the rejected your request. {}'.format(r.text)
+      raise BadValueError(error_message)
 
 def autograde_final_subs(assignment, user, data):
     subm_ids = {}
@@ -690,7 +691,7 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
         ModelProxy.Participant.course == assignment.course,
         ModelProxy.Participant.role == STUDENT_ROLE))
 
-    newly_created_fs = []
+    new_submission = []
     for participant in enrollment:
         student = participant.user.get()
         fs = student.get_final_submission(assignment.key)
@@ -702,12 +703,12 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
 
             # TODO: Also get submissions that weren't marked as final for some reason
             if chosen_backup:
-                new_sub = force_promote_backup(chosen_backup.key.id())
-                newly_created_fs.append(new_sub.id())
+                new_fsub = force_promote_backup(chosen_backup.key.id())
+                new_submission.append(new_fsub.submission.id())
                 logging.info("Promoted backup for {}".format(student.email[0]))
 
     if autograde:
-        return autograde_subms(assignment, user, data, newly_created_fs)
+        return autograde_subms(assignment, user, data, new_submission)
 
 
 def force_promote_backup(backup_id):

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -695,7 +695,7 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
         student = participant.user.get()
         fs = student.get_final_submission(assignment)
         if not fs:
-            backup_q = student.backups(group, assignment)
+            backup_q = student.backups(fs.group, assignment)
             elgible_backups = backup_q.filter(Backup.server_time <= assignment.due_date)
             chosen_backup = elgible_backups.get()
 

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -696,7 +696,11 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
         fs = student.get_final_submission(assignment)
         if not fs:
             recent_bck = student.get_backups(assignment.key, 1)[0]
-            new_sub = force_promote_backup(recent_bck.key.id())
+            try:
+                new_sub = force_promote_backup(recent_bck.key.id())
+            except ValueError:
+                continue
+            logging.info("Promoted student backup to final submission;")
             newly_created_fs.append(new_sub.id())
 
     if autograde:
@@ -717,10 +721,7 @@ def force_promote_backup(backup_id):
 
     assign = backup.assignment.get_async()
     subm = ModelProxy.Submission(backup=backup.key)
-    subm.put()
     return subm.mark_as_final()
-
-
 
 import difflib
 

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -669,7 +669,7 @@ def autograde_subms(assignment, user, data, subm_ids, priority="default"):
         # TODO: Contact staff (via email)
       return {'status_url': AUTOGRADER_URL+'/rq', 'length': str(len(subm_ids))}
     else:
-      error_message = 'The autograder the rejected your request. {}'.format(r.text)
+      error_message = 'The autograder rejected your request. {}'.format(r.text)
       raise BadValueError(error_message)
 
 def autograde_final_subs(assignment, user, data):
@@ -703,9 +703,10 @@ def promote_student_backups(assignment, autograde=False, user=None, data=None):
 
             # TODO: Also get submissions that weren't marked as final for some reason
             if chosen_backup:
-                new_fsub = force_promote_backup(chosen_backup.key.id())
+                back_id = chosen_backup.key.id()
+                new_fsub = force_promote_backup(back_id)
                 new_subm = new_fsub.get().submission
-                new_submissions[new_subm.id()] = new_subm.get().backup.id()
+                new_submissions[new_subm.id()] = back_id
                 logging.info("Promoted backup for {}".format(student.email[0]))
 
     if autograde:

--- a/server/tests/integration/test_api_assignment.py
+++ b/server/tests/integration/test_api_assignment.py
@@ -175,7 +175,7 @@ class AssignmentAPITest(APIBaseTestCase):
         """ Tests report for autograding failure """
         with self.assertRaises(BadValueError):
             import requests
-            self.mock(requests, 'post').using(lambda *args, **kwargs: self.obj().set(status_code=900))
+            self.mock(requests, 'post').using(lambda *args, **kwargs: self.obj().set(status_code=500, text="Not allowed"))
             # Use the deferred task - since that's where submission occurs.
             utils.autograde_final_subs(self._assign, self.accounts['dummy_admin'], {
                 'grade_final': True,

--- a/server/tests/integration/test_final_submissions.py
+++ b/server/tests/integration/test_final_submissions.py
@@ -338,6 +338,13 @@ class FinalSubmissionTest(APIBaseTestCase):
         # This backup is now late - and can't be submitted as a revision
         subm = models.Submission(backup=self.backups['first'].key)
         subm.put()
+        try:
+            api.FinalSubmissionAPI().post(self.user, dict(submission=subm.key))
+        except ValueError as e:
+            self.assertEqual(str(e), 'Cannot change submission after due date')
+
+        self.set_lock_date(NOW + datetime.timedelta(days=1))
+
 
         api.FinalSubmissionAPI().post(self.user, dict(submission=subm.key))
         self.assertFinalSubmission(self.user, self.backups['first'])


### PR DESCRIPTION
This fix has been deployed onto staging and seems to work. 

TODO:
 - Promote more than just the last backup. Attempt to hunt for the backup closest to the due-date. 
 - Lower Priority: Also consider submissions first if any exist (to handle edge cases where lock_dates/due_dates where off) 
- Write tests for auto promotion (coveralls fell below 89%) 
