### PR TITLE
Get All Scores/Handle Partners in Grade Export

### DIFF
--- a/server/app.yaml
+++ b/server/app.yaml
@@ -3,7 +3,7 @@ version: 1
 runtime: python27
 api_version: 1
 threadsafe: true
-instance_class: F2
+instance_class: F4_1G
 
 default_expiration: "5m"
 

--- a/server/app.yaml
+++ b/server/app.yaml
@@ -5,7 +5,7 @@ api_version: 1
 threadsafe: true
 instance_class: F2
 
-default_expiration: "10m"
+default_expiration: "5m"
 
 builtins:
 - appstats: on

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -1321,8 +1321,11 @@ class FinalSubmission(Base):
                   # Individual group:
                   if group_size == 1 and is_partnered:
                         # Score is an average of all partnered parts of project
-                        other_partner_parts = [sc for sc in subm_scores if 'partner' in sc[4]]
-                        average_score = int(sum([s[1] for s in other_partner_parts])/len(other_partner_parts))
+                        other_partner_parts = [sc for sc in subm_scores if 'partner' in sc[4].lower()]
+                        if not other_partner_parts:
+                            average_score = score[1]
+                        else:
+                            average_score = int(sum([s[1] for s in other_partner_parts])/len(other_partner_parts))
                         score[1] = average_score
                   elif is_partnered:
                         expected_letter = chr(97 + position) # 0 -> a, etc

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -1325,7 +1325,6 @@ class FinalSubmission(Base):
                         average_score = int(sum([s[1] for s in other_partner_parts])/len(other_partner_parts))
                         score[1] = average_score
                   elif is_partnered:
-                        # Only supports two member groups for now.
                         expected_letter = chr(97 + position) # 0 -> a, etc
                         if score[4].lower().strip() != "partner {}".format(expected_letter):
                             continue

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -424,7 +424,7 @@ class User(Base):
         existing_subms = [s[5] for s in scores]
         group = self.get_group(assignment)
 
-        submissions = self.submissions(group, assignment.key).fetch(5)
+        submissions = self.submissions(group, assignment.key).fetch(50)
 
         for subm in submissions:
             # Only include new submissions
@@ -1124,16 +1124,17 @@ class Group(Base):
         """
         content = []
         member = self.member[0].get()
-
+        success = False
         for m in self.member:
             member = m.get()
             if member:
               data, success = member.scores_for_assignment(assignment)
-
               content.extend(data)
-              if success:
-                  # get_scores_for_student_or_group will return scores for all group members.
-                  return content
+
+        if success:
+            # Might result in duplicates - but trying to see if this will give me all data
+            # get_scores_for_student_or_group will return scores for all group members.
+            return content
 
         # Handle the case where the member key no longer exists.
         if not member:

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -422,14 +422,19 @@ class User(Base):
         if fs:
             scores = fs.get_scores()
         existing_subms = [s[5] for s in scores]
-        submissions = self.get_submissions(assignment.key, num_submissions=50)  # Fetch all submissions as well
+        group = self.get_group(assignment)
+
+        submissions = self.submissions(group, assignment.key).fetch(5)
+
         for subm in submissions:
             # Only include new submissions
             subm_scores = [s for s in subm.export_scores() if s[5] not in existing_subms]
 
             for score in subm_scores:
                 score[0] = self.email[0] # Emails should for be the person recieving the grade
-                score.append(subm_scores)
+
+            if subm_scores:
+                scores.extend(subm_scores)
 
         return (scores, True) if scores else ([[self.email[0], 0, None, None, None, None, None, None]], False)
 

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -1321,7 +1321,7 @@ class FinalSubmission(Base):
                   # Individual group:
                   if group_size == 1 and is_partnered:
                         # Score is an average of all partnered parts of project
-                        other_partner_parts = [sc for sc in subm_scores if 'partner' in sc[[4]]]
+                        other_partner_parts = [sc for sc in subm_scores if 'partner' in sc[4]]
                         average_score = int(sum([s[1] for s in other_partner_parts])/len(other_partner_parts))
                         score[1] = average_score
                   elif is_partnered:

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -1128,8 +1128,6 @@ class Group(Base):
             member = m.get()
             if member:
               data, success = member.scores_for_assignment(assignment)
-              for score in data:
-                score[0] = member.email[0] # Emails should for be the person recieving the grade
 
               content.extend(data)
               if success:

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -152,9 +152,9 @@ def create_csv_content(content):
 def data_for_scores(assignment, user):
     """
     Returns a tuple of two values a list of lists of score info for assignment.
-    Format: [['STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG', 'SUBM_ID', 'REVISION_ID']]
+    Format: [['STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG', 'SUBM_ID', 'REVISION_ID', 'IS_FINAL']]
     """
-    content = [['STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG', 'SUBM_ID', 'REVISION_ID']]
+    content = [['STUDENT', 'SCORE', 'MESSAGE', 'GRADER', 'TAG', 'SUBM_ID', 'REVISION_ID', 'IS_FINAL']]
     course = assignment.course.get()
     groups = ModelProxy.Group.lookup_by_assignment(assignment)
     seen_members = set()

--- a/server/tests/regression/test_models.py
+++ b/server/tests/regression/test_models.py
@@ -202,6 +202,9 @@ class ModelsTestCase(BaseTestCase):
         # Repeating the process should get the same results
         self.assertEqual(scores_out, user2.scores_for_assignment(assign.get()))
 
+        # Getting the scores via the group should also have the same result
+        self.assertEqual(scores, group.get().scores_for_assignment(assign.get()))
+
     ##########
     # Course #
     ##########

--- a/server/tests/regression/test_models.py
+++ b/server/tests/regression/test_models.py
@@ -114,7 +114,7 @@ class ModelsTestCase(BaseTestCase):
         user = models.User(email=['yo@yo.com']).put().get()
         self.assertEqual(
             user.scores_for_assignment(assign),
-            ([[user.email[0], 0, None, None, None, None, None]], False))
+            ([[user.email[0], 0, None, None, None, None, None, None]], False))
 
     def test_scores_forassign_w_fs_wo_scores(self):
         """Tests that fs scores are loaded"""
@@ -151,8 +151,11 @@ class ModelsTestCase(BaseTestCase):
         user = user.get()
         self.assertNotEqual(user.get_final_submission(assign), None)
         scores_out = user.scores_for_assignment(assign.get())
-        self.assertTrue(len(scores_out[0]) == 1)
-        self.assertTrue(len(scores_out[0][0]) == 7)
+        self.assertTrue(len(scores_out[0]) == 2) # two submissions with scores
+        self.assertTrue(len(scores_out[0][0]) == 8) # test that both scores have len 8
+        self.assertTrue(len(scores_out[0][1]) == 8) # test that both scores have len 8
+
+        self.assertTrue(scores_out[0][0][7]) # first submission should be a final one
         self.assertEqual(scores_out[0][0][5], subm.id())
         self.assertEqual(scores_out[0][0][6], revision.id())
 

--- a/server/tests/regression/test_models.py
+++ b/server/tests/regression/test_models.py
@@ -136,7 +136,7 @@ class ModelsTestCase(BaseTestCase):
         assign = models.Assignment().put()
         user = models.User(email=['yo@yo.com']).put()
         backup = models.Backup(submitter=user, assignment=assign).put()
-        score = models.Score(score=10, grader=user, message="Nice!")
+        score = models.Score(score=10, grader=user, message="Nice!", tag="Total")
         subm = models.Submission(
             backup=backup,
             score=[score]).put()
@@ -151,13 +151,56 @@ class ModelsTestCase(BaseTestCase):
         user = user.get()
         self.assertNotEqual(user.get_final_submission(assign), None)
         scores_out = user.scores_for_assignment(assign.get())
-        self.assertTrue(len(scores_out[0]) == 2) # two submissions with scores
-        self.assertTrue(len(scores_out[0][0]) == 8) # test that both scores have len 8
-        self.assertTrue(len(scores_out[0][1]) == 8) # test that both scores have len 8
 
-        self.assertTrue(scores_out[0][0][7]) # first submission should be a final one
-        self.assertEqual(scores_out[0][0][5], subm.id())
-        self.assertEqual(scores_out[0][0][6], revision.id())
+        scores = scores_out[0]
+        self.assertEqual(len(scores), 1) # two scores from one submission
+        self.assertEqual(len(scores[0]), 8) # test that both scores have len 8
+        self.assertTrue(scores[0][7]) # first submission should be a final one
+        self.assertEqual(scores[0][5], subm.id())
+        self.assertEqual(scores[0][6], revision.id())
+
+    def test_scores_group_assign_w_fs_w_rev_scores(self):
+        """Tests that fs scores are loaded"""
+        assign = models.Assignment().put()
+        ag = models.User(email=['autograder@yo.com']).put()
+
+        member1 = models.User(email=['yo@yo.com']).put()
+        member2 = models.User(email=['therealyo@yo.com']).put()
+        group = make_fake_group(assign.get(), member1.get(), member2.get()).key
+
+        backup = models.Backup(submitter=member1, assignment=assign).put()
+        score = models.Score(score=10, grader=ag, message="All Correct", tag="Partner A")
+        score2 = models.Score(score=5, grader=ag, message="Not quite! Sorry!", tag="Partner B")
+        subm = models.Submission(
+            backup=backup,
+            score=[score, score2]).put()
+        revision = models.Submission(
+            backup=backup).put()
+        fs = models.FinalSubmission(
+            submitter=member1,
+            group=group,
+            assignment=assign,
+            submission=subm,
+            revision=revision).put()
+
+        user1 = member1.get()
+        user2 = member2.get()
+        self.assertNotEqual(user1.get_final_submission(assign), None)
+        scores_out = user1.scores_for_assignment(assign.get())
+
+        scores = scores_out[0]
+        self.assertEqual(len(scores), 2) # two scores from one submission
+        self.assertEqual(len(scores[0]), 8) # test that both scores have len 8
+        self.assertEqual(len(scores[1]), 8) # test that both scores have len 8
+
+        self.assertEqual(scores[0][0], user1.email[0])
+        self.assertEqual(scores[1][0], user2.email[0])
+
+        self.assertEqual(scores[0][1], score.score) # should get a 10
+        self.assertEqual(scores[1][1], score2.score)  # should get a 5
+
+        # Repeating the process should get the same results
+        self.assertEqual(scores_out, user2.scores_for_assignment(assign.get()))
 
     ##########
     # Course #


### PR DESCRIPTION
Grade export should get scores from all submissions (mainly for Scheme EC) but this could help in cases where students change the submission after the grade has been inputted. 

Partner Scores are limited to Final Submissions only at the moment (it made sense to put that logic there versus elsewhere)
