### PR TITLE
Log group actions - resolves #649

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -491,13 +491,15 @@ class Group(db.Model, TimestampMixin):
         if not assignment.active:
             raise BadRequest('The assignment is past due')
         group = Group.lookup(sender, assignment)
+        add_sender = group is None
         if not group:
             group = Group(assignment=assignment)
             db.session.add(group)
-            group._add_member(sender, 'active')
         elif not group.has_status(sender, 'active'):
             raise BadRequest('You are not in the group')
         with group._log('invite', sender.id, recipient.id):
+            if add_sender:
+                group._add_member(sender, 'active')
             group._add_member(recipient, 'pending')
 
     @transaction

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -183,10 +183,7 @@ class TestGroup(OkTestCase):
         state = {
             'id': group.id,
             'assignment_id': group.assignment_id,
-            'members': [{
-                'user_id': self.user1.id,
-                'status': 'active'
-            }]
+            'members': []
         }
 
         action = latest_action()
@@ -194,6 +191,10 @@ class TestGroup(OkTestCase):
         assert action.user_id == self.user1.id
         assert action.target_id == self.user2.id
         assert action.group_before == json.dumps(state)
+        state['members'].append({
+            'user_id': self.user1.id,
+            'status': 'active'
+        })
         state['members'].append({
             'user_id': self.user2.id,
             'status': 'pending'


### PR DESCRIPTION
Doesn't log creation and deletion, for ease of implementation. Instead, actions that start/end with a delete group will show up as a group with no members.