### PR TITLE
Add Version Model+API

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,7 @@ from flask.ext.script.commands import ShowUrls, Clean
 from flask.ext.migrate import Migrate, MigrateCommand
 from server import create_app
 from server.models import db, User, Course, Assignment, Enrollment, \
-    Backup, Message, Group
+    Backup, Message, Group, Version
 
 # default to dev config because no one should use this in
 # production anyway.
@@ -56,6 +56,14 @@ def seed():
     db.session.add_all(courses)
     future = datetime.now() + timedelta(days=1)
     db.session.commit()
+
+    # Add client version info.
+    okversion = Version(name="ok", current_version="v1.5.0",
+        download_link="https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.0/ok")
+    db.session.add(okversion)
+    okversion = Version(name="ok2", current_version="v1.5.0",
+        download_link="https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.0/ok")
+    db.session.add(okversion)
 
     students = [User(email='student{}@okpy.org'.format(i)) for i in range(60)]
     db.session.add_all(students)

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -31,7 +31,6 @@ from server.utils import encode_id
 import server.models as models
 
 
-
 endpoints = Blueprint('api', __name__)
 endpoints.config = {}
 

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -16,22 +16,20 @@ API.py - /api/{version}/endpoints
     api.add_resource(UserAPI, '/v3/user')
 """
 
-from flask import Blueprint, jsonify, request
-
-import flask_restful as restful
-from flask_restful import reqparse, fields, marshal_with
-
 import datetime
 import json
-
-from flask_restful.representations.json import output_json
-
 from functools import wraps
 
+from flask import Blueprint, jsonify, request
 from flask.ext.login import current_user
+import flask_restful as restful
+from flask_restful import reqparse, fields, marshal_with
+from flask_restful.representations.json import output_json
 
 from server.extensions import cache
+from server.utils import encode_id
 import server.models as models
+
 
 
 endpoints = Blueprint('api', __name__)

--- a/server/models.py
+++ b/server/models.py
@@ -590,3 +590,9 @@ class GroupAction(db.Model, TimestampMixin):
     # see Group.serialize for format
     group_before = db.Column(JSON)
     group_after = db.Column(JSON)
+
+class Version(db.Model, TimestampMixin, DictMixin):
+    id = db.Column(db.Integer(), primary_key=True)
+    name = db.Column(db.String(), nullable=False) # i.e "ok"
+    current_version = db.Column(db.String(), nullable=False)
+    download_link = db.Column(db.String())

--- a/server/models.py
+++ b/server/models.py
@@ -372,7 +372,10 @@ class Backup(db.Model, TimestampMixin, DictMixin):
             backup_id=self.id,
             kind='file_contents').first()
         if message:
-            return message.contents
+            contents = dict(message.contents)
+            # submit is not a real file, but the client sends it anyway
+            contents.pop('submit', None)
+            return contents
         else:
             return {}
 

--- a/server/models.py
+++ b/server/models.py
@@ -596,6 +596,7 @@ class GroupAction(db.Model, TimestampMixin):
 
 class Version(db.Model, TimestampMixin, DictMixin):
     id = db.Column(db.Integer(), primary_key=True)
-    name = db.Column(db.String(), nullable=False) # i.e "ok"
-    current_version = db.Column(db.String(), nullable=False)
-    download_link = db.Column(db.String())
+    # software name e.g. 'ok'
+    name = db.Column(db.String(255), nullable=False, unique=True, index=True)
+    current_version = db.Column(db.String(255), nullable=False)
+    download_link = db.Column(db.Text())

--- a/server/templates/diff.html
+++ b/server/templates/diff.html
@@ -34,10 +34,8 @@
 
 {% macro highlight_diffs(files_before, files_after) %}
   {% for filename in files_before.keys().__or__(files_after.keys()) | sort %}
-    {% if filename != 'submit' %}
     {{ highlight_diff(filename,
       files_before.get(filename, ''), files_after.get(filename, '')) }}
-    {% endif %}
   {% endfor %}
 {% endmacro %}
 
@@ -54,8 +52,6 @@
 
 {% macro highlight_files(files) %}
   {% for filename, source in files | dictsort %}
-    {% if filename != 'submit' %}
-      {{ highlight_file(filename, source) }}
-    {% endif %}
+    {{ highlight_file(filename, source) }}
   {% endfor %}
 {% endmacro %}

--- a/server/templates/diff.html
+++ b/server/templates/diff.html
@@ -34,8 +34,10 @@
 
 {% macro highlight_diffs(files_before, files_after) %}
   {% for filename in files_before.keys().__or__(files_after.keys()) | sort %}
+    {% if filename != 'submit' %}
     {{ highlight_diff(filename,
       files_before.get(filename, ''), files_after.get(filename, '')) }}
+    {% endif %}
   {% endfor %}
 {% endmacro %}
 
@@ -52,6 +54,8 @@
 
 {% macro highlight_files(files) %}
   {% for filename, source in files | dictsort %}
-    {{ highlight_file(filename, source) }}
+    {% if filename != 'submit' %}
+      {{ highlight_file(filename, source) }}
+    {% endif %}
   {% endfor %}
 {% endmacro %}

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -32,7 +32,11 @@
           <div class="stripe"></div>
           <div class="stripe"></div>
         </div>
-        <a href="{{ url_for('auth.login') }}" class="btn pill">Login</a>
+        {% if config['TESTING_LOGIN'] and config['ENV'] == 'dev' %}
+            <a href="{{ url_for('auth.testing_login') }}" class="btn pill">Login</a>
+        {% else %}
+            <a href="{{ url_for('auth.login') }}" class="btn pill">Login</a>
+        {% endif %}
 
       </div>
     </header>
@@ -42,7 +46,13 @@
         {% include 'alerts.html' %}
         <h1 class="title">Automate grading. Personalize feedback.</h1>
         <p>Ok autogrades coding assignments and facilitates code submission, review, composition, and analytics for advanced diagnoses for your class.</p>
-        <a href="{{ url_for('auth.login') }}" class="button">Login with Google</a>
+
+        {% if config['TESTING_LOGIN'] and config['ENV'] == 'dev' %}
+            <a href="{{ url_for('auth.testing_login') }}" class="button">Testing Login</a>
+        {% else %}
+            <a href="{{ url_for('auth.login') }}" class="button">Login with Google</a>
+        {% endif %}
+
       </div>
     </div>
   </body>

--- a/server/templates/testing-login.html
+++ b/server/templates/testing-login.html
@@ -8,7 +8,21 @@
             Login for Testing
         </div>
         <div class="login-box-body">
-            <p class="login-box-msg">Impersonate a user</p>
+            {% for user in ['okstaff@okpy.org', 'student0@okpy.org'] %}
+            <form action="{{ callback }}" method="post">
+                <div class="form-group has-feedback">
+                    <input type="hidden" value="{{user}}" class="form-control" name="email" placeholder="Email">
+                </div>
+                <div class="row">
+                    <button type="submit" class="btn btn-primary btn-block btn-flat">Sign In As {{user}}</button>
+                </div>
+            </form>
+            {% endfor %}
+        </div>
+
+        <div class="login-box-body">
+
+        <p class="login-box-msg">Impersonate a user</p>
 
             <form action="{{ callback }}" method="post">
                 <div class="form-group has-feedback">
@@ -16,7 +30,6 @@
                 </div>
                 <div class="row">
                     <button type="submit" class="btn btn-primary btn-block btn-flat">Sign In</button>
-                </div>
                 </div>
             </form>
         </div>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,7 +59,12 @@ class TestAuth(OkTestCase):
         assert response.json['data'] == {
             'email': email,
             'key': encode_id(backup.id),
-            'course': course.offering,
+            'course': {
+                'id': course.id,
+                'offering': course.offering,
+                'display_name': course.display_name,
+                'active': course.active
+            },
             'assignment': assignment.name
         }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from server.models import db, Assignment, Backup, Course, User, Version
+from server.utils import encode_id
 
 from .helpers import OkTestCase
 
@@ -57,9 +58,9 @@ class TestAuth(OkTestCase):
         self.assert_200(response)
         assert response.json['data'] == {
             'email': email,
-            'key': backup.id,
-            'course': course.id,
-            'assignment': assignment.id
+            'key': encode_id(backup.id),
+            'course': course.offering,
+            'assignment': assignment.name
         }
 
         assert backup.assignment == assignment

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from server.models import db, Assignment, Backup, Course, User
+from server.models import db, Assignment, Backup, Course, User, Version
 
 from .helpers import OkTestCase
 
@@ -21,17 +21,35 @@ class TestAuth(OkTestCase):
         db.session.add(assignment)
         db.session.commit()
 
+        okversion = Version(name="ok", current_version="v1.5.0",
+            download_link="http://localhost/ok")
+        db.session.add(okversion)
+
         data = {
             'assignment': assignment.name,
             'messages': {
                 'file_contents': {
-                    'hog.py': 'print "Hello world!"'
+                    'hog.py': 'print("Hello world!")'
                 }
             },
-            'submit': submit
+            'submit': submit,
         }
 
-        response = self.client.post('/api/v3/backups/', data=json.dumps(data),
+        response = self.client.post('/api/v3/backups/?client_version=v1.4.0',
+            data=json.dumps(data),
+            headers=[('Content-Type', 'application/json')])
+        self.assert_403(response)
+        assert response.json['data'] == {
+            'supplied': 'v1.4.0',
+            'correct': 'v1.5.0',
+            'download_link': "http://localhost/ok"
+        }
+        assert 'Incorrect client version' in response.json['message']
+        backup = Backup.query.filter(Backup.submitter_id == user.id).all()
+        assert backup == []
+
+        response = self.client.post('/api/v3/backups/?client_version=v1.5.0',
+            data=json.dumps(data),
             headers=[('Content-Type', 'application/json')])
         backup = Backup.query.filter(Backup.submitter_id == user.id).first()
         assert backup is not None
@@ -54,3 +72,58 @@ class TestAuth(OkTestCase):
 
     def test_submit(self):
         self._test_backup(True)
+
+    def test_api(self):
+        response = self.client.get('/api/v3/')
+        self.assert_200(response)
+        assert response.json['data'] == {
+            'version': 'v3',
+            'url': '/api/v3/',
+            'documentation': 'http://github.com/Cal-CS-61A-Staff/ok/wiki'
+        }
+        assert response.json['message'] == 'success'
+        assert response.json['code'] == 200
+
+    def test_non_existant_api(self):
+        response = self.client.get('/api/v3/doesnotexist')
+        self.assert_404(response)
+        assert response.json['data'] == {}
+        assert response.json['code'] == 404
+
+    def test_version_api(self):
+        okversion = Version(name="ok", current_version="v1.5.0",
+            download_link="http://localhost/ok")
+        db.session.add(okversion)
+        ok2version = Version(name="ok2", current_version="v2.5.0",
+            download_link="http://localhost/ok2")
+        db.session.add(ok2version)
+
+        response = self.client.get('/api/v3/version/')
+        self.assert_200(response)
+        assert response.json['data'] == {
+            'results': [
+                {
+                    "current_version": "v1.5.0",
+                    "download_link": "http://localhost/ok",
+                    "name": "ok"
+                },
+                {
+                    "current_version": "v2.5.0",
+                    "download_link": "http://localhost/ok2",
+                    "name": "ok2"
+                }
+            ]
+        }
+        assert response.json['message'] == 'success'
+
+        response = self.client.get('/api/v3/version/ok')
+        self.assert_200(response)
+        assert response.json['data'] == {
+            'results': [
+                {
+                    "current_version": "v1.5.0",
+                    "download_link": "http://localhost/ok",
+                    "name": "ok"
+                }
+            ]
+        }

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -98,7 +98,7 @@ class TestSubmission(OkTestCase):
         assert not submission.flagged
 
     def test_files(self):
-         backup = Backup(
+        backup = Backup(
             client_time=datetime.datetime.now(),
             submitter_id=self.user1.id,
             assignment=self.assignment,
@@ -109,7 +109,7 @@ class TestSubmission(OkTestCase):
             contents={
                 'hog.py': 'def foo():\n    return',
                 'submit': True
-            }
+            })
         db.session.add(message)
         db.session.add(backup)
         db.session.commit()

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -97,3 +97,24 @@ class TestSubmission(OkTestCase):
         group.accept(self.user1)
         assert not submission.flagged
 
+    def test_files(self):
+         backup = Backup(
+            client_time=datetime.datetime.now(),
+            submitter_id=self.user1.id,
+            assignment=self.assignment,
+            submit=True)
+        message = Message(
+            kind='file_contents',
+            backup=backup,
+            contents={
+                'hog.py': 'def foo():\n    return',
+                'submit': True
+            }
+        db.session.add(message)
+        db.session.add(backup)
+        db.session.commit()
+
+        # submit should not show up
+        assert backup.files() == {
+            'hog.py': 'def foo():\n    return'
+        }


### PR DESCRIPTION
Resolves #681
- Versions now have a model + API
- Submission/Backups now use the version value sent by the client instead of a hardcoded value
- Ok Client changes were made to account for the renaming of current_download_link to download_link 

Design changes from v2: We don't store previous version info. We never really used that information. 

- Entirely unrelated changes (didn't want to make a separate PR for these)
  - Enrollment API is protected by some permissions now (this requires some minor changes to ok-client)
  - login links to testing login in dev mode
  - Quick Links on testing-login to login to staff/student accounts

