### PR TITLE
If no pygments lexer, don't highlight file

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -79,7 +79,13 @@ def seed():
     db.session.add(assign2)
     db.session.commit()
 
-    messages = {'file_contents': {'difflib.py': modified_file}, 'analytics': {}}
+    messages = {
+        'file_contents': {
+            'difflib.py': modified_file,
+            'moby_dick': 'Call me Ishmael.'
+        },
+        'analytics': {}
+    }
     for i in range(20):
         for submit in (False, True):
             time = datetime.now()-timedelta(days=i)

--- a/server/highlight.py
+++ b/server/highlight.py
@@ -7,9 +7,13 @@ import pygments.formatters
 
 def highlight(filename, source):
     """Highlights an input string into a list of HTML strings, one per line."""
-    return pygments.highlight(source,
-        pygments.lexers.guess_lexer_for_filename(filename, source, stripnl=False),
-        pygments.formatters.HtmlFormatter(nowrap=True)).splitlines(keepends=True)
+    try:
+        highlighted = pygments.highlight(source,
+            pygments.lexers.guess_lexer_for_filename(filename, source, stripnl=False),
+            pygments.formatters.HtmlFormatter(nowrap=True))
+    except pygments.util.ClassNotFound:
+        highlighted = source
+    return highlighted.splitlines(keepends=True)
 
 def highlight_file(filename, source):
     """Given a source file, generate a sequence of (line index, HTML) pairs."""

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -88,3 +88,15 @@ class TestHighlight(OkTestCase):
     def test_highlight_diff(self):
         for a, b in itertools.combinations(self.files.values(), 2):
             self._test_highlight_diff('test.py', a, b)
+
+    def test_no_highlight(self):
+        filename = 'data'
+        source = 'It was the best of times, it was the worst of times, ...'
+
+        source_lines = source.splitlines(keepends=True)
+        highlighted = list(highlight.highlight_file(filename, source))
+
+        for i, highlighted_line in highlighted:
+            assert source_lines[i - 1] == highlighted_line
+
+        assert source_lines == [line for _, line in highlighted]


### PR DESCRIPTION
Fixes #689. Scroll down to the bottom a submission to see a plaintext file that's not highlighted.