### PR TITLE
Adds form for updating client versions

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -5,7 +5,7 @@ from functools import wraps
 import pytz
 import csv
 
-from server.models import User, Course, Assignment, Enrollment, db
+from server.models import User, Course, Assignment, Enrollment, Version, db
 from server.constants import STAFF_ROLES, VALID_ROLES, STUDENT_ROLE
 import server.forms as forms
 
@@ -70,6 +70,26 @@ def index():
     return render_template('staff/index.html', courses=courses)
 
 
+@admin.route("/client/<name>", methods=['GET', 'POST'])
+@is_staff()
+def client_version(name):
+    version = Version.query.filter_by(name=name).one()
+
+    form = forms.VersionForm(obj=version)
+    if form.validate_on_submit():
+        model = version
+        form.populate_obj(model)
+
+        db.session.add(model)
+        db.session.commit()
+
+        flash(name + " version updated successfully.", "success")
+        return redirect(url_for(".client_version", name=name))
+
+    return render_template('staff/client_version.html',
+                            version=version, form=form)
+
+
 @admin.route("/course/<int:cid>")
 @is_staff(course_arg='cid')
 def course(cid):
@@ -132,6 +152,7 @@ def assignment(cid, aid):
     return render_template('staff/course/assignment.html', assignment=assgn,
                            form=form, courses=courses,
                            current_course=current_course)
+
 
 @admin.route("/course/<int:cid>/enrollment", methods=['GET', 'POST'])
 @is_staff(course_arg='cid')

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -77,10 +77,9 @@ def client_version(name):
 
     form = forms.VersionForm(obj=version)
     if form.validate_on_submit():
-        model = version
-        form.populate_obj(model)
+        form.populate_obj(version)
 
-        db.session.add(model)
+        db.session.add(version)
         db.session.commit()
 
         flash(name + " version updated successfully.", "success")

--- a/server/forms.py
+++ b/server/forms.py
@@ -82,6 +82,14 @@ class EnrollmentForm(BaseForm):
     role = SelectField(u'Role',
                        choices=[(r, r.capitalize()) for r in VALID_ROLES])
 
+
+class VersionForm(BaseForm):
+    current_version = EmailField(u'Current Version',
+                        validators=[validators.required()])
+    download_link = StringField(u'Download Link',
+                        validators=[validators.required(), validators.url()])
+
+
 class BatchEnrollmentForm(BaseForm):
     csv = TextAreaField(u'Email, Name, SID, Course Login, Section')
 

--- a/server/generate.py
+++ b/server/generate.py
@@ -173,6 +173,13 @@ def seed_backups():
             db.session.add_all(backups)
         db.session.commit()
 
+def seed_versions():
+    print('Seeding version...')
+    url = 'https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.4/ok'
+    ok = Version(name='ok-client', current_version='v1.5.4', download_link=url)
+    db.session.add(ok)
+    db.session.commit()
+
 def seed():
     random.seed(0)
     seed_users()
@@ -184,4 +191,4 @@ def seed():
     # TODO: submission flagging
     # TODO: comments
     # TODO: scores
-    # TODO: versions
+    seed_versions()

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -1,19 +1,18 @@
 ENV = 'test'
 SECRET_KEY = 'samplekey'
+CACHE_TYPE = 'simple'
 
 DEBUG = True
-TESTING = True
 ASSETS_DEBUG = True
 TESTING_LOGIN = True
 DEBUG_TB_INTERCEPT_REDIRECTS = False
 
 SQLALCHEMY_TRACK_MODIFICATIONS = False
-SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://okdev:okdev@db/okdev'
+SQLALCHEMY_DATABASE_URI = 'sqlite:///../oksqlite.db'
+WTF_CSRF_CHECK_DEFAULT = False
+WTF_CSRF_ENABLED = False
 
-CACHE_TYPE = 'redis'
-CACHE_REDIS_URL = 'redis://redis:6379/0'
-CACHE_KEY_PREFIX = 'ok-server'
-
-RQ_LOW_URL = 'redis://redis:6379/1'
+CACHE_TYPE = 'simple'
 
 GOOGLE_CONSUMER_KEY = ''
+

--- a/server/templates/staff/client_version.html
+++ b/server/templates/staff/client_version.html
@@ -1,0 +1,60 @@
+{% extends "staff/base.html" %}
+{% import 'staff/_formhelpers.html' as forms %}
+
+{% block title %} {{ version.name }} Version {% endblock %}
+
+{% block main %}
+  <section class="content-header">
+      <h1>
+        {{ version.name }} Version
+      </h1>
+      <ol class="breadcrumb">
+        <li><a href="{{ url_for(".index") }}"><i class="fa fa-dashboard"></i> Home</a></li>
+        <li><a href="#"><i class="fa fa-desktop"></i> Client Version</a></li>
+
+      </ol>
+  </section>
+
+  <section class="content">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible">
+              <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+              {{message}}
+            </div>
+        {% endfor %}
+    {% endif %}
+    {% endwith %}
+
+      <div class="col-md-12 col-xs-12">
+        <!-- Default box -->
+        <!--  Box -->
+        <div class="box">
+          <div class="box-header with-border">
+            <div class="box-tools pull-right">
+              <button type="button" class="btn btn-box-tool" data-widget="collapse" data-toggle="tooltip" title="Collapse">
+                <i class="fa fa-minus"></i>
+              </button>
+            </div>
+          </div>
+          <div class="box-body">
+              {% call forms.render_form(form, action_url="", action_text='Update Client Version',
+                                          class_='form') %}
+                  {{ forms.render_field(form.current_version, label_visible=true, placeholder='v1.5.4', type='text') }}
+                  {{ forms.render_field(form.download_link, label_visible=true, placeholder='https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.4/ok', type='text') }}
+              {% endcall %}
+          </div>
+          <!-- /.box-body -->
+          <!-- /.box-footer-->
+        </div>
+
+
+      </div>
+    </div>
+
+  </section>
+
+
+  <!-- </body> do not close body in template-->
+{% endblock %}

--- a/server/templates/staff/sidebar.html
+++ b/server/templates/staff/sidebar.html
@@ -79,6 +79,9 @@
         <li><a href="https://cal-cs-61a-staff.github.io/ok/">
             <i class="fa fa-book"></i> <span>Documentation</span></a>
         </li>
+        <li><a href="{{ url_for('.client_version', name='ok-client') }}">
+            <i class="fa fa-desktop"></i> <span>ok-client Version</span></a>
+        </li>
         <li><a href="{{ url_for('student.index' )}}">
             <i class="fa fa-graduation-cap"></i> <span>Student Dashboard</span></a>
         </li>

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,7 +8,7 @@ from server.models import db, Assignment, Course, Enrollment, User
 
 class OkTestCase(TestCase):
     def create_app(self):
-        return create_app('settings/dev.py')
+        return create_app('settings/test.py')
 
     def setUp(self):
         db.create_all()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -26,13 +26,9 @@ class TestVersion(OkTestCase):
             "current_version": "v1.6.0",
             "download_link": "https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.4/ok"
         }
-        update_form = VersionForm(obj=old)
-        update_form.current_version = data['current_version']
-        update_form.download_link = data['download_link']
         
         response = self.client.post('/admin/client/ok-client',
-                        data=data, follow_redirects=True,
-                        headers=[('Content-Type', 'application/x-www-form-urlencoded')])
+                        data=data, follow_redirects=True)
         
         assert response.status_code == 200
         

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,41 @@
+import datetime
+import json
+from server.models import db, Assignment, Backup, Course, User, Version
+from server.utils import encode_id
+from server.forms import VersionForm
+
+from tests import OkTestCase
+
+class TestVersion(OkTestCase):
+    
+    def setUp(self):
+        super().setUp()
+        self.admin = User(email="admin@okpy.org", is_admin=True)
+        db.session.add(self.admin)
+        db.session.commit()
+    
+    def test_version_form(self):
+        old = Version(name="ok-client", current_version="v1.5.0",
+            download_link="http://localhost/ok")
+        db.session.add(old)
+        db.session.commit()
+        
+        self.login(self.admin.email)
+        
+        data = {
+            "current_version": "v1.6.0",
+            "download_link": "https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.4/ok"
+        }
+        update_form = VersionForm(obj=old)
+        update_form.current_version = data['current_version']
+        update_form.download_link = data['download_link']
+        
+        response = self.client.post('/admin/client/ok-client',
+                        data=data, follow_redirects=True,
+                        headers=[('Content-Type', 'application/x-www-form-urlencoded')])
+        
+        assert response.status_code == 200
+        
+        new = Version.query.filter_by(name="ok-client").one()
+        assert new.current_version == data['current_version']
+        assert new.download_link == data['download_link']


### PR DESCRIPTION
This adds a form at `/admin/client/<client-name>` that can be used to update
the version and download link for a client (currently, only 'ok-client').

It also adds an 'ok-client' version to the seed data and a link to
`/admin/client/ok-client` in the admin/staff sidebar.

This should close #706.