### PR TITLE
Unflag all submissions after group creation

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -743,7 +743,8 @@ class Group(Model):
             raise BadRequest('{0} is not invited to this group'.format(user.email))
         with self._log('accept', user.id, user.id):
             member.status = 'active'
-        self.assignment._unflag_all(self.assignment.active_user_ids(user.id))
+        for member in self.assignment.active_user_ids(user.id):
+            self.assignment._unflag_all([member])
 
     @transaction
     def decline(self, user):


### PR DESCRIPTION
This allows members who both had flagged submissions before the group was created to form a group. 

Resolves #751 