### PR TITLE
Keep existing flags of group members on accept

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -743,8 +743,7 @@ class Group(Model):
             raise BadRequest('{0} is not invited to this group'.format(user.email))
         with self._log('accept', user.id, user.id):
             member.status = 'active'
-        for member in self.assignment.active_user_ids(user.id):
-            self.assignment._unflag_all([member])
+        self.assignment._unflag_all([user.id])
 
     @transaction
     def decline(self, user):


### PR DESCRIPTION
When a user accepts an invite - their flagged submissions are unflagged and they "join" the group and take on whatever submission the group already had.

I think this is better than unflagging all submissions for the entire group.