### PR TITLE
Catch invalid HashIds in converter

### DIFF
--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -336,7 +336,11 @@ class ScoreSchema(APISchema):
 
     def add_score(self, user):
         args = self.parse_args()
-        backup = models.Backup.query.get(decode_id(args['bid']))
+        try:
+            bid = decode_id(args['bid'])
+        except (ValueError, TypeError):
+            restful.abort(404)
+        backup = models.Backup.query.get(bid)
         kind = args['kind'].lower().strip()
         score, message = args['score'], args['message']
         score = make_score(user, backup, score, message, kind)
@@ -387,7 +391,11 @@ class Backup(Resource):
     def get(self, user, key=None):
         if key is None:
             restful.abort(405)
-        bid = decode_id(key)
+        try:
+            bid = decode_id(key)
+        except (ValueError, TypeError):
+            restful.abort(404)
+
         backup = self.model.query.filter_by(id=bid).first()
         if not backup:
             if user.is_admin:

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -15,8 +15,6 @@ API.py - /api/{version}/endpoints
 
     api.add_resource(UserAPI, '/v3/user')
 """
-
-import json
 from functools import wraps
 
 from flask import Blueprint, jsonify, request, url_for
@@ -46,22 +44,6 @@ def record_params(setup_state):
 api = restful.Api(endpoints)
 
 API_VERSION = 'v3'
-
-def json_field(field):
-    """
-    Parses field or list, or returns appropriate boolean value.
-
-    :param field: (string)
-    :return: (string) parsed JSON
-    """
-    if not field[0] in ['{', '[']:
-        if field == 'false':
-            return False
-        elif field == 'true':
-            return True
-        return field
-    return json.dumps(field)
-
 
 class HashIDField(fields.Raw):
     def format(self, value):

--- a/server/converters.py
+++ b/server/converters.py
@@ -19,7 +19,7 @@ class HashidConverter(BaseConverter):
     def to_python(self, value):
         try:
             return utils.decode_id(value)
-        except TypeError as e:
+        except (TypeError, ValueError) as e:
             raise ValidationError(str(e))
 
     def to_url(self, value):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,6 +113,20 @@ class TestAuth(OkTestCase):
         assert response.json['data'] == {}
         assert response.json['code'] == 404
 
+    def test_bad_hashid(self):
+        self.setup_course()
+
+        response = self.client.get('/api/v3/backups/xyzxyz/')
+        self.assert_401(response)
+        assert response.json['data'] == {}
+        assert response.json['code'] == 401
+
+        self.login(self.user1.email)
+        response = self.client.get('/api/v3/backups/xyzxyz/')
+        self.assert_404(response)
+        assert response.json['data'] == {}
+        assert response.json['code'] == 404
+
     def test_version_api(self):
         okversion = Version(name="ok", current_version="v1.5.0",
             download_link="http://localhost/ok")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -39,6 +39,20 @@ class TestDownload(OkTestCase):
         self.assert_200(response)
         self.assertEqual(contents, response.data.decode('UTF-8'))
 
+    def test_incorrect_hash(self):
+        filename = "test.py"
+        contents = "x = 4"
+        self._add_file(filename, contents)
+        encoded_id = utils.encode_id(self.backup.id)
+        submit_str = "submissions" if self.backup.submit else "backups"
+        url = "/{0}/{1}/{2}/download/{3}".format(self.assignment.name, submit_str, "xxxxx", filename)
+        response = self.client.get(url)
+        self.assert_404(response)
+        url = "/{0}/{1}/{2}/download/{3}".format(self.assignment.name, submit_str, "123", filename)
+        response = self.client.get(url)
+        self.assert_404(response)
+
+
     def test_incorrect_submit_boolean(self):
         filename = "test.py"
         contents = "x = 4"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -52,7 +52,6 @@ class TestDownload(OkTestCase):
         response = self.client.get(url)
         self.assert_404(response)
 
-
     def test_incorrect_submit_boolean(self):
         filename = "test.py"
         contents = "x = 4"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -169,6 +169,12 @@ if driver:
             self.assertTrue("student1@aol.com" not in self.driver.page_source)
             self.assertTrue("No Submission" in self.driver.page_source)
 
+        def test_student_invalid_hash(self):
+            self._seed_course()
+            self._login_as(email=self.user4.email)
+            self.driver.get("{}/cal/cs61a/sp16/proj1/xyz".format(self.get_server_url()))
+            self.assertIn('404', self.driver.title)
+
         def test_login_admin_reject(self):
             self._login(role="student")
             self.pageLoad(self.get_server_url() + "/admin/")


### PR DESCRIPTION
Resolves #766 

The earlier errors in Sentry were because we threw ValueErrors and didn't catch those in the converter. 