### PR TITLE
Hide Assignments from student view

### DIFF
--- a/migrations/versions/ed0359c3b84b_add_hidden_assignments.py
+++ b/migrations/versions/ed0359c3b84b_add_hidden_assignments.py
@@ -1,0 +1,22 @@
+"""Add Hidden Assignments
+
+Revision ID: ed0359c3b84b
+Revises: ca9a10db0a21
+Create Date: 2016-08-08 16:23:01.121388
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ed0359c3b84b'
+down_revision = 'ca9a10db0a21'
+
+from alembic import op
+import sqlalchemy as sa
+import server
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.add_column('assignment', sa.Column('visible', sa.Boolean(), default=True))
+
+def downgrade():
+    op.drop_column('assignment', 'visible')

--- a/server/controllers/student.py
+++ b/server/controllers/student.py
@@ -73,9 +73,12 @@ def course(offering):
         return assignment, submission_time, group, final_submission
 
     course = get_course(offering)
+
     assignments = {
-        'active': [assignment_info(a) for a in course.assignments if a.active],
-        'inactive': [assignment_info(a) for a in course.assignments if not a.active]
+        'active': [assignment_info(a) for a in course.assignments
+                   if a.active and a.visible],
+        'inactive': [assignment_info(a) for a in course.assignments
+                     if not a.active and a.visible]
     }
     return render_template('student/course/index.html', course=course,
                            **assignments)

--- a/server/forms.py
+++ b/server/forms.py
@@ -58,25 +58,27 @@ class AssignmentForm(BaseForm):
                 self.lock_date.data = utils.local_time_obj(
                     obj.lock_date, course)
 
-    display_name = StringField(u'Display Name',
+    display_name = StringField('Display Name',
                                validators=[validators.required()])
-    name = StringField(u'Offering (example: cal/cs61a/sp16/lab01)',
+    name = StringField('Offering (example: cal/cs61a/sp16/lab01)',
                        validators=[validators.required()])
-    due_date = DateTimeField(u'Due Date (Course Time)',
+    due_date = DateTimeField('Due Date (Course Time)',
                              default=dt.datetime.now,
                              validators=[validators.required()])
-    lock_date = DateTimeField(u'Lock Date (Course Time)',
+    lock_date = DateTimeField('Lock Date (Course Time)',
                               default=dt.datetime.now,
                               validators=[validators.required()])
-    max_group_size = IntegerField(u'Max Group Size',
+    max_group_size = IntegerField('Max Group Size',
                                   default=1,
                                   validators=[validators.InputRequired(),
                                               validators.number_range(min=1)])
-    url = StringField(u'URL',
+    url = StringField('URL',
                       validators=[validators.optional(), validators.url()])
-    revisions_allowed = BooleanField(u'Enable Revisions', default=False,
+    revisions_allowed = BooleanField('Enable Revisions', default=False,
                                      validators=[validators.optional()])
-    autograding_key = StringField(u'Autograder Key', [validators.optional()])
+    visible = BooleanField('Visible On Student Dashboard', default=True)
+    autograding_key = StringField('Autograder Key',
+                                  validators=[validators.optional()])
 
     def populate_obj(self, obj):
         """ Updates obj attributes based on form contents. """
@@ -130,27 +132,27 @@ class AssignmentTemplateForm(BaseForm):
 
 
 class EnrollmentForm(BaseForm):
-    name = StringField(u'Name', validators=[validators.optional()])
-    email = EmailField(u'Email',
+    name = StringField('Name', validators=[validators.optional()])
+    email = EmailField('Email',
                        validators=[validators.required(), validators.email()])
-    sid = StringField(u'SID', validators=[validators.optional()])
-    secondary = StringField(u'Secondary Auth (e.g Username)',
+    sid = StringField('SID', validators=[validators.optional()])
+    secondary = StringField('Secondary Auth (e.g Username)',
                             validators=[validators.optional()])
-    section = StringField(u'Section',
+    section = StringField('Section',
                           validators=[validators.optional()])
-    role = SelectField(u'Role',
+    role = SelectField('Role',
                        choices=[(r, r.capitalize()) for r in VALID_ROLES])
 
 
 class VersionForm(BaseForm):
-    current_version = EmailField(u'Current Version',
+    current_version = EmailField('Current Version',
                                  validators=[validators.required()])
-    download_link = StringField(u'Download Link',
+    download_link = StringField('Download Link',
                                 validators=[validators.required(), validators.url()])
 
 
 class BatchEnrollmentForm(BaseForm):
-    csv = TextAreaField(u'Email, Name, SID, Course Login, Section')
+    csv = TextAreaField('Email, Name, SID, Course Login, Section')
 
     def validate(self):
         check_validate = super(BatchEnrollmentForm, self).validate()

--- a/server/models.py
+++ b/server/models.py
@@ -241,6 +241,7 @@ class Assignment(Model):
     display_name = db.Column(db.String(255), nullable=False)
     due_date = db.Column(db.DateTime(timezone=True), nullable=False)
     lock_date = db.Column(db.DateTime(timezone=True), nullable=False)
+    visible = db.Column(db.Boolean(), default=True)
     creator_id = db.Column(db.ForeignKey("user.id"))
     url = db.Column(db.Text)
     max_group_size = db.Column(db.Integer(), nullable=False, default=1)

--- a/server/templates/staff/course/assignment.html
+++ b/server/templates/staff/course/assignment.html
@@ -156,6 +156,7 @@
                   {{ forms.render_field(form.url, label_visible=true, placeholder='http://cs61a.org/proj/hog (Optional)', type='text') }}
                   {{ forms.render_field(form.autograding_key, label_visible=true, placeholder='5abc... (Optional)', type='text') }}
                   {{ forms.render_checkbox_field(form.revisions_allowed, label_visible=true) }}
+                  {{ forms.render_checkbox_field(form.visible, label_visible=true) }}
               {% endcall %}
           </div>
           <!-- /.box-body -->

--- a/server/templates/staff/course/assignment.new.html
+++ b/server/templates/staff/course/assignment.new.html
@@ -49,6 +49,7 @@
                   {{ forms.render_field(form.url, label_visible=true, placeholder='http://cs61a.org/proj/hog (Optional)', type='text') }}
                   {{ forms.render_field(form.autograding_key, label_visible=true, placeholder='5abc... (Optional)', type='text') }}
                   {{ forms.render_checkbox_field(form.revisions_allowed, label_visible=true) }}
+                  {{ forms.render_checkbox_field(form.visible, label_visible=true) }}
               {% endcall %}
             </div>
           </div>

--- a/server/templates/staff/course/assignments.html
+++ b/server/templates/staff/course/assignments.html
@@ -37,6 +37,7 @@
                 <tbody><tr>
                   <th>Name</th>
                   <th>Offering</th>
+                  <th>Visible</th>
                   <th>Due Date</th>
                   <th>Lock Date</th>
                 </tr>
@@ -45,6 +46,13 @@
                 <tr>
                   <td><a href="{{ url_for('.assignment', cid=current_course.id, aid=asgn.id) }}">{{ asgn.display_name }}</a></td>
                   <td>{{ asgn.name }}</td>
+                  <td>
+                      {% if asgn.visible %}
+                        <span class="label label-success">Visible</span>
+                      {% else %}
+                        <span class="label label-warning">Hidden</span>
+                      {% endif %}
+                  </td>
                   <td>{{ utils.local_time(asgn.due_date, current_course) }}</td>
                   <td>{{ utils.local_time(asgn.lock_date, current_course) }}</td>
                 </tr>
@@ -71,7 +79,8 @@
             <table class="table table-striped">
                 <tbody><tr>
                   <th>Name</th>
-                  <th>ID</th>
+                  <th>Offering</th>
+                  <th>Visible</th>
                   <th>Due Date</th>
                   <th>Lock Date</th>
                 </tr>
@@ -80,6 +89,13 @@
                 <tr>
                   <td><a href="{{ url_for('.assignment', cid=current_course.id, aid=asgn.id) }}">{{ asgn.display_name }}</a></td>
                   <td>{{ asgn.name }}</td>
+                  <td>
+                      {% if asgn.visible %}
+                        <span class="label label-success">Visible</span>
+                      {% else %}
+                        <span class="label label-warning">Hidden</span>
+                      {% endif %}
+                  </td>
                   <td>{{ utils.local_time(asgn.due_date, current_course) }}</td>
                   <td>{{ utils.local_time(asgn.lock_date, current_course) }}</td>
                 </tr>


### PR DESCRIPTION
Adds a visible column to assignments to hide certain assignments from student view. 

This can be useful for unreleased homeworks or accidently created assignments. 

Deleting assignments is not as simple as deleting the row since the corresponding backups and scores for the assignment would also have to be deleted.

We could make this an actual soft-delete where it removes the assignment from the admin dashboard as well (and the endpoint name is free to use) but I don't see a big advantage to that. 

TODO (before merge): 
- [x] Generate migration 
- [x] Run Migration