### PR TITLE
Groups API 

### DIFF
--- a/documentation/api.md
+++ b/documentation/api.md
@@ -207,10 +207,6 @@ curl "https://ok.cs61a.org/api/v3/assignment/cal/cs61a/sp16/lab01/group/email@ex
 {
     "code": 200,
     "data": {
-        "assignment": {
-            "course": { ... },
-            "name": "cal/cs61a/sp16/lab01"
-        },
         "members": [
             {
                 "created": "2016-08-16T20:54:28",
@@ -252,7 +248,6 @@ access_token | None | (Required) Access Token of staff member
 Parameter | Type | Description
 ---------- | ------- | -------
 members | List | List of members if available. If there is no group, this value is equal to `[]`
-assignment | Dictionary | The assignment name and the course info.
 
 See example output for fields.
 `member['status']` is either "pending" or "active"
@@ -343,11 +338,7 @@ curl "https://ok.cs61a.org/api/v3/assignment/cal/cs61a/sp16/lab00/submissions?ac
         "id": "lejRe2",
         "email": "email@berkeley.edu"
     },
-    "assignment": {
-        "name": "cal/cs61a/su16/sample",
-        "course": {"id": 1, "active": true, "display_name": "CS 61A", "offering": "cal/cs61a/su16"}
-    }
-}, ],
+    },],
 "count": 36,
 },
 "code": 200

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -138,7 +138,7 @@ Get the courses that a specific user is enrolled in. Used by ok-client to see if
 The access_token must belong to the email being requested or be an OK admin.
 
 #### HTTP Request
-`GET https://ok.cs61a.org/api/v3/enrollment/<string:email>`
+`GET https://ok.cs61a.org/api/v3/enrollment/<string:email>/`
 
 #### Query Parameters
 Parameter | Default | Description
@@ -152,10 +152,115 @@ See example response.
 
 # Assignments
 
+## Assignment Info
+>><h4> Example Response </h4>
+> ```
+curl "https://ok.cs61a.org/api/v3/assignment/cal/cs61a/sp16/lab01"
+{
+    "code": 200,
+    "data": {
+        "course": {
+            "active": true,
+            "display_name": "CS 61A",
+            "id": 1,
+            "offering": "cal/cs61a/sp16"
+        },
+        "display_name": "Lab 01",
+        "due_date": "2016-09-07T06:59:59",
+        "files": {
+            "fizzbuzz.py": "if ..."
+        },
+        "max_group_size": 2,
+        "name": "cal/cs61a/sp16/lab01",
+        "url": null
+    },
+    "message": "success"
+}
+```
+
+Get detailed assignment info.
+
+#### Permissions
+Requires an access token. The assignment is presented to all staff members of the course or admins but is only shown to other users if the staff marked the assignment as visible .
+
+#### HTTP Request
+`GET https://ok.cs61a.org/api/v3/assignment/<assignment_name:endpoint>``
+
+#### Query Parameters
+Parameter | Default | Description
+---------- | ------- | -------
+access_token | None | (Required) Access Token of staff member
+
+#### Response
+Name | Type | Description
+---------- | -------
+due_date | DateTime | UTC Time of deadline in iso8601 format.
+files | Dictionary | Template file names and contents
+name | String | Endpoint
+
+See example output for other fields.
+
+## Group Info
+>><h4> Example Response </h4>
+> ```
+curl "https://ok.cs61a.org/api/v3/assignment/cal/cs61a/sp16/lab01/group/email@example.com"
+{
+    "code": 200,
+    "data": {
+        "assignment": {
+            "course": { ... },
+            "name": "cal/cs61a/sp16/lab01"
+        },
+        "members": [
+            {
+                "created": "2016-08-16T20:54:28",
+                "status": "active",
+                "updated": null,
+                "user": {
+                    "email": "email@example.com",
+                    "id": "mbk5ez"
+                }
+            },
+            {
+                "created": "2016-08-16T20:54:28",
+                "status": "pending",
+                "updated": null,
+                "user": {
+                    "email": "okstaff@okpy.org",
+                    "id": "nel5aK"
+                }
+            }
+        ]
+    },
+    "message": "success"
+}```
+
+Get detailed assignment info.
+
+#### Permissions
+Requires an access token. The group info is presented to all staff members of the course or admins. Otherwise, the access_token must belong to the user whose email is in the URL to get a response.
+
+#### HTTP Request
+`GET https://ok.cs61a.org/api/v3/assignment/<assignment_name:endpoint>/group/<string:email>`
+
+#### Query Parameters
+Parameter | Default | Description
+---------- | ------- | -------
+access_token | None | (Required) Access Token of staff member
+
+#### Response
+Parameter | Type | Description
+---------- | ------- | -------
+members | List | List of members if available. If there is no group, this value is equal to `[]`
+assignment | Dictionary | The assignment name and the course info.
+
+See example output for fields.
+`member['status']` is either "pending" or "active"
+
 ## Export Backups
 >><h4> Example Response </h4>
 > ```
-curl "https://ok.cs61a.org/api/v3/assignment/1/exportemail@berkeley.edu?access_token=test&limit=2&offset=17"
+curl "https://ok.cs61a.org/api/v3/assignment/cal/cs61a/sp16/lab00/export/email@berkeley.edu?access_token=test&limit=2&offset=17"
 {
     "code": 200,
     "message": "success",
@@ -193,7 +298,7 @@ The access_token's user must have permission to view the backup. They must have
 at least staff level access to the assignment.
 
 #### HTTP Request
-`GET https://ok.cs61a.org/api/v3/assignment/<int:aid>/export/<string:email>`
+`GET https://ok.cs61a.org/api/v3/assignment/<assignment_name:endpoint>/export/<string:email>`
 
 #### Query Parameters
 Parameter | Default | Description
@@ -214,7 +319,7 @@ offset | Integer | The value of the limit parameter
 ## Export Final Submissions
 >><h4> Example Response </h4>
 > ```
-curl "https://ok.cs61a.org/api/v3/assignment/1/submissions?access_token=test"
+curl "https://ok.cs61a.org/api/v3/assignment/cal/cs61a/sp16/lab00/submissions?access_token=test"
 {
 "message": "success",
 "data": {
@@ -255,7 +360,7 @@ Get all submissions for a course. This obtains all submissions for an assignment
 The access_token's user must have at least staff level access to the assignment.
 
 #### HTTP Request
-`GET https://ok.cs61a.org/api/v3/assignment/<int:aid>/submissions/`
+`GET https://ok.cs61a.org/api/v3/assignment/<assignment_name:endpoint>/submissions/`
 
 #### Query Parameters
 Parameter | Default | Description

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -221,7 +221,6 @@ class GroupSchema(APISchema):
     }
     get_fields = {
         'members': fields.List(fields.Nested(member_fields)),
-        'assignment': fields.Nested(AssignmentSchema.simple_fields)
     }
 
 
@@ -664,7 +663,7 @@ class Group(Resource):
     def get(self, user, name, email):
         assign = models.Assignment.by_name(name)
         target = models.User.lookup(email)
-        default_value = {'assignment': assign, 'members': []}
+        default_value = {'members': []}
 
         if not assign:
             restful.abort(404)

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -184,6 +184,7 @@ class CourseSchema(APISchema):
         'offering': fields.String,
         'display_name': fields.String,
         'active': fields.Boolean,
+        'timezone': fields.String
     }
 
 

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -27,6 +27,7 @@ from server.extensions import cache
 from server.utils import encode_id, decode_id
 import server.models as models
 from server.autograder import submit_continous
+from server.constants import STAFF_ROLES
 
 endpoints = Blueprint('api', __name__)
 endpoints.config = {}
@@ -195,8 +196,31 @@ class UserSchema(APISchema):
 
 class AssignmentSchema(APISchema):
     get_fields = {
+        'due_date': fields.DateTime(dt_format='iso8601'),
+        'display_name': fields.String,
+        'name': fields.String,
+        'max_group_size': fields.Integer,
+        'url': fields.String,
+        'course': fields.Nested(CourseSchema.get_fields),
+        'files': fields.Raw
+    }
+
+    simple_fields = {
         'course': fields.Nested(CourseSchema.get_fields),
         'name': fields.String,
+    }
+
+
+class GroupSchema(APISchema):
+    member_fields = {
+        'status': fields.String,
+        'user': fields.Nested(UserSchema.get_fields),
+        'updated': fields.DateTime(dt_format='iso8601'),
+        'created': fields.DateTime(dt_format='iso8601'),
+    }
+    get_fields = {
+        'members': fields.List(fields.Nested(member_fields)),
+        'assignment': fields.Nested(AssignmentSchema.simple_fields)
     }
 
 
@@ -204,7 +228,7 @@ class BackupSchema(APISchema):
     get_fields = {
         'id': HashIDField,  # Use Hash ID
         'submitter': fields.Nested(UserSchema.get_fields),
-        'assignment': fields.Nested(AssignmentSchema.get_fields),
+        'assignment': fields.Nested(AssignmentSchema.simple_fields),
         'messages': fields.List(fields.Nested(MessageSchema.get_fields)),
         'created': fields.DateTime(dt_format='iso8601'),
         'is_late': fields.Boolean,
@@ -436,7 +460,8 @@ class Revision(Resource):
 
         # Only accept revision if the assignment has revisions enabled
         if not assignment.revisions_allowed:
-            return restful.abort(403, message="Revisions are not enabled for this assignment",
+            return restful.abort(403,
+                                 message="Revisions are not enabled for this assignment",
                                  data={'backup': True, 'late': True})
 
         # Only accept revision if the user has a FS
@@ -481,9 +506,8 @@ class ExportBackup(Resource):
     model = models.Assignment
 
     @marshal_with(schema.export_list)
-    def get(self, user, aid, email):
-        assign = (self.model.query.filter_by(id=aid)
-                      .one_or_none())
+    def get(self, user, name, email):
+        assign = models.Assignment.by_name(name)
         target = models.User.lookup(email)
 
         limit = request.args.get('limit', 150, type=int)
@@ -523,9 +547,8 @@ class ExportFinal(Resource):
     model = models.Assignment
 
     @marshal_with(schema.full_export_list)
-    def get(self, user, aid):
-        assign = (self.model.query.filter_by(id=aid)
-                      .one_or_none())
+    def get(self, user, name):
+        assign = models.Assignment.by_name(name)
 
         if not assign:
             if user.is_admin:
@@ -611,12 +634,69 @@ class Version(PublicResource):
             versions = self.model.query.all()
         return {'results': versions}
 
+class Assignment(Resource):
+    """ Infromation about an assignment
+    Authenticated. Permissions: >= User
+    Used by: Collaboration/Scripts
+    """
+    model = models.Assignment
+    schema = AssignmentSchema()
+
+    @marshal_with(schema.get_fields)
+    def get(self, user, name):
+        assign = self.model.by_name(name)
+        if not assign:
+            restful.abort(404)
+        elif not self.model.can(assign, user, 'view'):
+            restful.abort(403)
+        return assign
+
+class Group(Resource):
+    """ Infromation about a group member by email.
+    Authenticated. Permissions: >= User
+    Used by: Collaboration/Scripts
+    """
+    model = models.Group
+    schema = GroupSchema()
+
+    @marshal_with(schema.get_fields)
+    def get(self, user, name, email):
+        assign = models.Assignment.by_name(name)
+        target = models.User.lookup(email)
+        default_value = {'assignment': assign, 'members': []}
+
+        if not assign:
+            restful.abort(404)
+        elif not target and user.is_admin:
+            restful.abort(404)
+        elif not target:
+            restful.abort(403)
+
+        group = self.model.lookup(target, assign)
+        is_admin = user.is_admin
+        is_staff = user.is_enrolled(assign.course.id, STAFF_ROLES)
+        is_self = user.email.lower() == email.lower()
+
+        if is_self or is_staff or is_admin:
+            if group:
+                return group
+            else:
+                return default_value
+        restful.abort(403)
 
 api.add_resource(V3Info, '/v3/')
+
+# Submission endpoints
 api.add_resource(Backup, '/v3/backups/', '/v3/backups/<string:key>/')
 api.add_resource(Revision, '/v3/revision/')
-api.add_resource(ExportBackup, '/v3/assignment/<int:aid>/export/<string:email>')
-api.add_resource(ExportFinal, '/v3/assignment/<int:aid>/submissions/')
+
+# Assignment Info
+ASSIGNMENT_BASE = '/v3/assignment/<assignment_name:name>'
+api.add_resource(Assignment, ASSIGNMENT_BASE)
+api.add_resource(Group, ASSIGNMENT_BASE + '/group/<string:email>')
+api.add_resource(ExportBackup, ASSIGNMENT_BASE + '/export/<string:email>')
+api.add_resource(ExportFinal, ASSIGNMENT_BASE + '/submissions/')
+# Other
 api.add_resource(Enrollment, '/v3/enrollment/<string:email>/')
 api.add_resource(Score, '/v3/score/')
 api.add_resource(Version, '/v3/version/', '/v3/version/<string:name>')

--- a/server/controllers/student.py
+++ b/server/controllers/student.py
@@ -1,7 +1,6 @@
-from flask import Blueprint, render_template, flash, request, redirect, \
-    url_for, abort, make_response
-from flask_login import login_required, \
-    current_user
+from flask import (Blueprint, render_template, flash, request, redirect,
+                   url_for, abort, make_response)
+from flask_login import login_required, current_user
 from werkzeug.exceptions import BadRequest
 
 import collections
@@ -12,8 +11,8 @@ from server.constants import VALID_ROLES, STAFF_ROLES, STUDENT_ROLE
 from server.extensions import cache
 from server.forms import CSRFForm, UploadSubmissionForm
 from server.models import User, Course, Assignment, Group, Backup, db
-from server.utils import is_safe_redirect_url, group_action_email, \
-    invite_email, send_email
+from server.utils import (is_safe_redirect_url, group_action_email,
+                          invite_email, send_email)
 
 student = Blueprint('student', __name__)
 

--- a/server/models.py
+++ b/server/models.py
@@ -266,9 +266,10 @@ class Assignment(Model):
             return False
         if user.is_admin:
             return True
+        is_staff = user.is_enrolled(obj.course.id, STAFF_ROLES)
         if action == "view":
-            return user.is_authenticated
-        return user.is_enrolled(obj.course.id, STAFF_ROLES)
+            return is_staff or obj.visible
+        return is_staff
 
     @staticmethod
     @cache.memoize(900)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -216,6 +216,24 @@ class TestAuth(OkTestCase):
         self.assertEquals(response.json['data']['offset'], 20)
         self.assertEquals(response.json['data']['has_more'], False)
 
+    def test_export_final(self):
+        self._test_backup(True)
+        student = User.lookup(self.user1.email)
+
+        backup = Backup.query.filter(Backup.submitter_id == student.id).first()
+        endpoint = '/api/v3/assignment/{0}/submissions/'.format(self.assignment.name)
+
+        response = self.client.get(endpoint)
+        self.assert_403(response)
+
+        self.login(self.staff1.email)
+        response = self.client.get(endpoint)
+        self.assert_200(response)
+        backups = response.json['data']['backups']
+        self.assertEquals(len(backups), 1)
+        self.assertEquals(response.json['data']['count'], 1)
+
+
     def test_assignment_api(self):
         self._test_backup(True)
         student = User.lookup(self.user1.email)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import json
-from server.models import db, Assignment, Backup, Course, User, Version
+from server.models import (db, Assignment, Backup, Course, User,
+                           Version, Group)
 from server.utils import encode_id
 
 from tests import OkTestCase
@@ -195,7 +196,7 @@ class TestAuth(OkTestCase):
 
         backup = Backup.query.filter(Backup.submitter_id == student.id).first()
 
-        endpoint = '/api/v3/assignment/{0}/export/{1}'.format(self.assignment.id,
+        endpoint = '/api/v3/assignment/{0}/export/{1}'.format(self.assignment.name,
                                                           student.email)
         response = self.client.get(endpoint)
         self.assert_200(response)
@@ -214,6 +215,83 @@ class TestAuth(OkTestCase):
         self.assertEquals(response.json['data']['limit'], 2)
         self.assertEquals(response.json['data']['offset'], 20)
         self.assertEquals(response.json['data']['has_more'], False)
+
+    def test_assignment_api(self):
+        self._test_backup(True)
+        student = User.lookup(self.user1.email)
+        endpoint = '/api/v3/assignment/{0}'.format(self.assignment.name)
+        # View a public assignment
+        response = self.client.get(endpoint)
+        self.assert_200(response)
+        # Change assignment to be hidden
+        self.assignment.visible = False
+        db.session.commit()
+        response = self.client.get(endpoint)
+        self.assert_403(response)
+
+        self.assignment.visible = True
+        db.session.commit()
+
+        self.login(self.staff1.email)
+        response = self.client.get(endpoint)
+        self.assert_200(response)
+        self.assertEquals(response.json['data']['name'], self.assignment.name)
+
+        # Hidden assignment, but should be visible to staff
+        self.assignment.visible = False
+        db.session.commit()
+        response = self.client.get(endpoint)
+        self.assert_200(response)
+
+        self.login(self.user1.email)
+        self.assignment.visible = False
+        db.session.commit()
+        response = self.client.get(endpoint)
+        self.assert_403(response)
+
+
+    def test_group_api(self):
+        self._test_backup(True)
+        self.logout()
+
+        student = User.lookup(self.user1.email)
+
+        Group.invite(self.user1, self.user2, self.assignment)
+        group = Group.lookup(self.user1, self.assignment)
+        group.accept(self.user2)
+        base_api = '/api/v3/assignment/{0}/group/{1}'
+        endpoint = base_api.format(self.assignment.name, self.user1.email)
+
+        response = self.client.get(endpoint)
+        self.assert_401(response)
+
+        self.login(self.user1.email)
+        response = self.client.get(endpoint)
+        self.assert_200(response)
+        members = response.json['data']['members']
+        self.assertEquals(len(members), 2)
+        assert 'email' in members[0]['user']
+
+        self.login(self.staff1.email)
+        response = self.client.get(endpoint)
+
+        self.assert_200(response)
+        members = response.json['data']['members']
+        self.assertEquals(len(members), 2)
+        assert 'email' in  members[0]['user']
+
+        # Login as some random user
+        self.login(self.user3.email)
+        response = self.client.get(endpoint)
+        self.assert_403(response)
+
+        # Check for existence of email
+        response = self.client.get(base_api.format(self.assignment.name, 'oski61@example.com'))
+        self.assert_403(response)
+
+        self.login(self.admin.email)
+        response = self.client.get(base_api.format(self.assignment.name, 'oski61@example.com'))
+        self.assert_404(response)
 
     def test_score_staff(self):
         self._test_backup(True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,7 +62,8 @@ class TestAuth(OkTestCase):
                     'id': course.id,
                     'offering': course.offering,
                     'display_name': course.display_name,
-                    'active': course.active
+                    'active': course.active,
+                    'timezone': 'America/Los_Angeles'
                 },
                 'assignment': assignment.name
             }


### PR DESCRIPTION
Adds group & assignment endpoints to the API. 

Used by the collaborative editor. 

Also: 
- Changed other endpoints to avoid needing to know the database ID. 
- Cleanup
- Documentation updates 