### PR TITLE
Cache Google User Info

### DIFF
--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -18,13 +18,24 @@ then
 fi
 
 echo "Deploying image cs61a/ok-server:"$tag_name
-read -p "Are you sure you want to deploy? " -n 1 -r
+read -p "Deploy to staging? " -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
     echo "Watch with 'watch kubectl get pods'"
-    kubectl set image deployment/ok-web-deployment ok-v3-deploy=cs61a/ok-server:$tag_name
-    kubectl rollout status deployment/ok-web-deployment
+    kubectl set image deployment/ok-staging-deployment ok-v3-staging=cs61a/ok-server:$tag_name
+    kubectl rollout status deployment/ok-staging-deployment
     kubectl get pods
-    echo "Done"
+    echo "Deployed to staging. Run command again if you want to deploy to production"
+else
+    read -p "Are you sure you want to deploy to production? " -n 1 -r
+    echo    # (optional) move to a new line
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        echo "Watch with 'watch kubectl get pods'"
+        kubectl set image deployment/ok-web-deployment ok-v3-deploy=cs61a/ok-server:$tag_name
+        kubectl rollout status deployment/ok-web-deployment
+        kubectl get pods
+        echo "Done"
+    fi
 fi

--- a/server/controllers/auth.py
+++ b/server/controllers/auth.py
@@ -88,7 +88,6 @@ def user_from_email(email):
 @cache.memoize(1800)
 def google_user_data(token):
     """ Query google for a user's info. """
-    logger.info("Querying google for user information")
     if not token:
         return None
     resp = google_auth.get('userinfo', token=(token, ''))

--- a/server/controllers/auth.py
+++ b/server/controllers/auth.py
@@ -92,7 +92,7 @@ def google_user_data(token):
         return None
     resp = google_auth.get('userinfo', token=(token, ''))
     if resp.status != 200:
-        logger.error("Could not authenticated {}", resp.data)
+        logger.error("Could not authenticate {}", resp.data)
         return None
     return resp.data
 

--- a/server/models.py
+++ b/server/models.py
@@ -1067,7 +1067,7 @@ class Version(Model):
     download_link = db.Column(db.Text())
 
     @staticmethod
-    @cache.memoize(1000)
+    @cache.memoize(1800)
     def get_current_version(name):
         version = Version.query.filter_by(name=name).one_or_none()
         if version:


### PR DESCRIPTION
We should avoid hitting Google for access tokens on every request from the ok-client. This will help us cache the response from Google. 

This also helps avoid the random instances of increased latency on Google API (which causes Ok to throw a 500 after it timeouts).  