### PR TITLE
Fix spelling of Address on OAuth auth page

### DIFF
--- a/server/templates/auth/oauthorize.html
+++ b/server/templates/auth/oauthorize.html
@@ -30,7 +30,7 @@
                 <li class="list-group-item"> &raquo; Enrollment Status </li>
                 <li class="list-group-item"> &raquo; Group Status </li>
             {% elif scope == 'email' %}
-                <li class="list-group-item"> Your Email Adresss ({{ current_user.email }}) </li>
+                <li class="list-group-item"> Your Email Address ({{ current_user.email }}) </li>
                 <li class="list-group-item"> Enrollment Status </li>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
Signed-off-by: Colin Schoen <cschoen@berkeley.edu>