### PR TITLE
Force SSL on non API routes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ Flask-WTF==0.12
 Flask-RESTful==0.3.5
 Flask-Testing==0.5.0
 Flask-RQ==0.2
+Flask-SSLify==0.1.5
 
 # Flask DB Extensions
 Flask-SQLAlchemy==2.1

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -5,7 +5,7 @@ from markdown import markdown
 from flask import Flask, render_template, g, request
 from flask import Markup
 from flask_rq import RQ
-from flask_wtf.csrf import CsrfProtect
+from flask_sslify import SSLify
 from webassets.loaders import PythonLoader as PythonAssetsLoader
 from werkzeug.contrib.fixers import ProxyFix
 
@@ -65,6 +65,9 @@ def create_app(default_config_path=None):
         app.logger.addHandler(logging.StreamHandler())
         app.logger.setLevel(logging.INFO)
 
+        # SSL Force
+        sslify = SSLify(app, age=300, skips=['api'])
+
     @app.errorhandler(404)
     def not_found_error(error):
         if request.path.startswith("/api"):
@@ -85,7 +88,6 @@ def create_app(default_config_path=None):
 
     # initialize SQLAlchemy
     db.init_app(app)
-
 
     # Flask-Login manager
     login_manager.init_app(app)

--- a/server/extensions.py
+++ b/server/extensions.py
@@ -3,7 +3,6 @@ from flask_wtf.csrf import CsrfProtect
 from flask_debugtoolbar import DebugToolbarExtension
 from flask_assets import Environment
 from flask_oauthlib.provider import OAuth2Provider
-
 from raven.contrib.flask import Sentry
 
 # Setup flask cache

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -3,7 +3,7 @@ import os
 ENV = 'test'
 SECRET_KEY = os.getenv('OK_SESSION_KEY', 'testkey')
 
-DEBUG = False
+DEBUG = True
 ASSETS_DEBUG = False
 TESTING_LOGIN = True
 DEBUG_TB_INTERCEPT_REDIRECTS = False


### PR DESCRIPTION
```
$ http http://..../api/v3/

{
    "code": 200,
    "data": {
        "documentation": "https://okpy.github.io/documentation",
        "github": "https://github.com/Cal-CS-61A-Staff/ok",
        "url": "/api/v3/",
        "version": "v3"
    },
    "message": "success"
}
```

```
$ http http://.../
HTTP/1.1 302 FOUND
Connection: keep-alive
Content-Length: 259
Content-Type: text/html; charset=utf-8
Date: Wed, 21 Sep 2016 19:51:23 GMT
Location: https://ok-prod.cs61a.org/
Server: nginx/1.10.1
```