### PR TITLE
Prevent Cross-Site Scripting

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -8,6 +8,7 @@ from flask_rq import RQ
 from flask_wtf.csrf import CsrfProtect
 from webassets.loaders import PythonLoader as PythonAssetsLoader
 from werkzeug.contrib.fixers import ProxyFix
+from jinja2 import escape
 
 from server import assets, converters, utils
 from server.forms import CSRFForm
@@ -108,7 +109,7 @@ def create_app(default_config_path=None):
     })
 
     app.jinja_env.filters.update({
-        'markdown': lambda data: Markup(markdown(data)),
+        'markdown': lambda data: Markup(markdown(escape(data))),
         'pluralize': utils.pluralize
     })
 


### PR DESCRIPTION
The Markup class assumes that the string is HTML safe. Therefore no
filtering is performed on comments. This fix uses jinja2.escape()
before the data is passed to the markdown class, ensuring that all
HTML tags are properly filtered.