### PR TITLE
Real-time comment previews

### DIFF
--- a/server/static/css/code.css
+++ b/server/static/css/code.css
@@ -166,15 +166,10 @@ table.highlight tr:last-child td.comment-container {
   color: #333;
   font-size: 14px;
   line-height: 1.6;
-  padding: 15px;
+  margin: 15px;
 }
 
 /* Editor */
-.comment-editor-header {
-  background: #f7f7f7;
-  border-radius: 3px 3px 0 0;
-}
-
 .comment-editor .nav {
   padding: 6px 10px 0;
 }
@@ -188,40 +183,25 @@ table.highlight tr:last-child td.comment-container {
   pointer-events: none;
 }
 
-.comment-write {
-  margin: 10px;
-}
-
 .comment-preview {
-  margin: 10px;
   border-bottom: 1px solid #eee;
+  margin-bottom: 15px;
 }
 
 .comment-editor textarea {
   width: 100%;
-  min-height: 100px;
-  max-height: 500px;
-  padding: 10px;
+  padding: 15px;
   resize: vertical;
-
   color: #333;
   background-color: #fafafa;
-  background-position: right 8px center;
-  border: 1px solid #ddd;
-  border-radius: 3px;
+  border: none;
+  border-bottom: 1px solid #eee;
   outline: none;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.075);
-}
-
-.comment-editor textarea:focus {
-  background-color: #fff;
-  border-color: #51a7e8;
-  box-shadow:inset 0 1px 2px rgba(0,0,0,0.075), 0 0 5px rgba(81,167,232,0.5);
 }
 
 .comment-editor-actions {
   float: right;
-  margin: 0 10px 10px 0;
+  margin: 0 15px 15px 0;
 }
 
 /* Markdown */

--- a/server/static/js/comments.js
+++ b/server/static/js/comments.js
@@ -32,6 +32,14 @@ jQuery(document).ready(function($){
      * the editor is for a new comment.
      */
     var editorTemplate = $('#editor-template').html();
+    var markdown = window.markdownit();
+
+    /* Render Markdown content as HTML in the comment editor. */
+    function render(editor) {
+        var content = editor.find('textarea').val();
+        var html = content ? markdown.render(content) : '<p>Nothing to preview</p>';
+        editor.find('.markdown-body').empty().append(html);
+    }
 
     /* Remove a comment or editor and, if necessary, its container. */
     function removeComment(comment) {
@@ -60,6 +68,7 @@ jQuery(document).ready(function($){
         if (editor.length == 0) {
             container.append(editorTemplate);
         }
+        render(container.find('.comment-editor'));
     });
 
     $('body').on('click', '.comment-edit', function (e) {
@@ -69,6 +78,7 @@ jQuery(document).ready(function($){
         editor.find('textarea').val(comment.data('message'));
         comment.before(editor);
         comment.hide();
+        render(editor);
     });
 
     $('body').on('click', '.comment-delete', function (e) {
@@ -92,26 +102,11 @@ jQuery(document).ready(function($){
         });
     });
 
-    $('body').on('click', '.comment-write-tab', function (e) {
-        e.preventDefault();
-        $(this).tab('show');
+    $('body').on('change keyup paste cut', '.comment-write', 
+            debounce(function(e) {
         var editor = $(this).parents('.comment-editor');
-        editor.find('.comment-write').addClass('active');
-        editor.find('.comment-preview').removeClass('active');
-    });
-
-    $('body').on('click', '.comment-preview-tab', function (e) {
-        e.preventDefault();
-        $(this).tab('show');
-        var editor = $(this).parents('.comment-editor');
-        editor.find('.comment-write').removeClass('active');
-        editor.find('.comment-preview').addClass('active');
-
-        var markdown = window.markdownit();
-        var content = editor.find('textarea').val();
-        var html = content ? markdown.render(content) : '<p>Nothing to preview</p>';
-        editor.find('.markdown-body').empty().append(html);
-    });
+        render(editor);
+    }, 250));
 
     $('body').on('click', '.comment-cancel', function(e) {
         e.preventDefault();
@@ -160,4 +155,5 @@ jQuery(document).ready(function($){
             swal('Oops, something went wrong. Try again?', 'error');
         })
     });
+
 });

--- a/server/static/js/comments.js
+++ b/server/static/js/comments.js
@@ -107,8 +107,9 @@ jQuery(document).ready(function($){
         editor.find('.comment-write').removeClass('active');
         editor.find('.comment-preview').addClass('active');
 
+        var markdown = window.markdownit();
         var content = editor.find('textarea').val();
-        var html = content ? markdown.toHTML(content) : '<p>Nothing to preview</p>';
+        var html = content ? markdown.render(content) : '<p>Nothing to preview</p>';
         editor.find('.markdown-body').empty().append(html);
     });
 

--- a/server/static/js/comments.js
+++ b/server/static/js/comments.js
@@ -106,7 +106,7 @@ jQuery(document).ready(function($){
             debounce(function(e) {
         var editor = $(this).parents('.comment-editor');
         render(editor);
-    }, 250));
+    }, 75));
 
     $('body').on('click', '.comment-cancel', function(e) {
         e.preventDefault();

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -33,7 +33,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown.js/0.5.0/markdown.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.0.1/markdown-it.min.js"></script>
     {% assets "common_js" %}
       <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}

--- a/server/templates/diff.html
+++ b/server/templates/diff.html
@@ -25,21 +25,15 @@
 
 {% macro editor_template() %}
   <div class="comment comment-editor clearfix">
-    <ul class="comment-editor-header nav nav-tabs">
-      <li class="tabnav-tab active"><a class="btn-link comment-write-tab" data-toggle="tab">Write</a></li>
-      <li class="tabnav-tab"><a class="btn-link comment-preview-tab" data-toggle="tab">Preview</a></li>
-    </ul>
-    <div class="tab-content">
-      <div class="comment-write tab-pane active">
-        <textarea placeholder="Leave a comment"></textarea>
-      </div>
-      <div class="comment-preview tab-pane">
-        <div class="comment-body markdown-body"></div>
-      </div>
+    <div class="comment-write">
+      <textarea placeholder="Leave a comment" rows="8"></textarea>
+    </div>
+    <div class="comment-preview">
+      <div class="comment-body markdown-body"></div>
     </div>
     <div class="comment-editor-actions">
       <button class="btn btn-default comment-cancel">Cancel</button>
-      <button class="btn btn-success comment-save">Save</button>
+      <button class="btn btn-primary comment-save">Save</button>
     </div>
   </div>
 {% endmacro %}


### PR DESCRIPTION
Resolves #926.

![image](https://cloud.githubusercontent.com/assets/1915715/19546445/c1f76410-9644-11e6-91ab-08bf96a83eb8.png)

Real-time comment previews with debouncing. Some of the styles are from #925, so the code blocks don't look as nice as they are in the screenshot.