### PR TITLE
Allow zero scores in GradeForm

### DIFF
--- a/server/forms.py
+++ b/server/forms.py
@@ -276,7 +276,7 @@ class CSRFForm(BaseForm):
 
 
 class GradeForm(BaseForm):
-    score = DecimalField('Score', validators=[validators.required()])
+    score = DecimalField('Score', validators=[validators.InputRequired()])
     message = TextAreaField('Message', validators=[validators.required()])
     kind = SelectField('Kind', choices=[(c, c.title()) for c in SCORE_KINDS],
                        validators=[validators.required()])


### PR DESCRIPTION
validators.required() does not allow falsey values