### PR TITLE
Tune NGINX for Google Cloud Load Balancer

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -8,8 +8,13 @@ server {
     # set the correct host(s) for your site
     server_name default_server;
 
-    keepalive_timeout 5;
-    client_max_body_size 20M;
+
+    keepalive_timeout 650;
+    keepalive_requests 10000;
+    # See https://blog.percy.io/tuning-nginx-behind-google-cloud-platform-http-s-load-balancer-305982ddb340
+
+    client_max_body_size 30M;
+
 
     location /static/ {
         include  /etc/nginx/mime.types;

--- a/server/forms.py
+++ b/server/forms.py
@@ -65,10 +65,10 @@ class BackupUploadField(FileField):
         files = {}
         for upload in request.files.getlist(self.name):
             data = upload.read()
-            if len(data) > 10 * 1024 * 1024:  # file is too large (over 8 MB)
+            if len(data) > 15 * 1024 * 1024:  # file is too large (over 15 MB)
                 self.errors.append(
                     '{} is larger than the maximum file size '
-                    'of 8MB'.format(upload.filename))
+                    'of 15MB'.format(upload.filename))
                 return False
             try:
                 files[upload.filename] = str(data, 'utf-8')


### PR DESCRIPTION
Resolves #924 

Also increases max upload per file to 15M - to handle course staff request.