### PR TITLE
Show latest backup on student overview page

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -318,7 +318,7 @@ class Assignment(Model):
 
     user_assignment = namedtuple('UserAssignment',
                                  ['assignment', 'subm_time', 'group',
-                                  'final_subm', 'scores'])
+                                  'final_subm', 'scores', 'latest_backup'])
 
     @hybrid_property
     def active(self):
@@ -503,6 +503,7 @@ class Assignment(Model):
         """
         user_ids = self.active_user_ids(user.id)
         final_submission = self.final_submission(user_ids)
+        latest_backup = self.backups(user_ids).first()
         submission_time = final_submission and final_submission.created
         group = Group.lookup(user, self)
         scores = self.scores(user_ids, only_published=not staff_view)
@@ -512,6 +513,7 @@ class Assignment(Model):
             group=group,
             final_subm=final_submission,
             scores=scores,
+            latest_backup=latest_backup
         )
 
     def course_submissions(self, include_empty=True):

--- a/server/templates/staff/student/assignment.list.html
+++ b/server/templates/staff/student/assignment.list.html
@@ -21,6 +21,7 @@
                 <th class="sort" data-sort="group">Group</th>
                 <th class="sort" data-sort="submission-time">Time Submitted</th>
                 <th>Final Submission</th>
+                <th>Latest Backup</th>
                 <th class="sort" data-sort="scores">Scores</th>
                 <th>Actions</th>
             </thead>
@@ -66,6 +67,19 @@
                         </td>
 
                     {% endif %}
+
+                    {% if item.latest_backup %}
+                        <td class="latest-backup-id">
+                            <a href="{{ url_for('.grading', bid=item.latest_backup.id) }}" title="Backup created at {{ utils.local_time(item.latest_backup.created, current_course) }}">
+                                {{ item.latest_backup.hashid }}
+                            </a>
+                        </td>
+                    {% else %}
+                        <td class="latest-backup-id">
+                            <i class="fa fa-times-circle text-red" aria-hidden="true"></i>
+                        </td>
+                    {% endif %}
+
                     <td class="scores">
                       {{ helpers.score_pills(item.scores) }}
                     </td>

--- a/server/templates/student/course/_assigntable.html
+++ b/server/templates/student/course/_assigntable.html
@@ -14,7 +14,7 @@
           <th class="col-status">Status</th>
           <th class="col-group">Group</th>
         </tr>
-        {% for assign, subm_time, group, fs, scores in assignments %}
+        {% for assign, subm_time, group, fs, scores, latest_backup in assignments %}
         <tr>
           <td>
             <span>
@@ -63,7 +63,14 @@
               <span class="due-text green">Submitted</span>
               <span class="due-date">{{ utils.local_time(subm_time, course) }}</span>
             </div>
-            {% else %}
+          {% elif latest_backup %}
+            <div class="due-dot yellow"></div>
+            <div class="due">
+              <span class="due-text grey">No Submission</span>
+              <span class="due-date">Backup: {{ utils.local_time(subm_time, course) }}</span>
+            </div>
+
+          {% else %}
             <div class="due-dot grey"></div>
             <div class="due">
               <span class="due-text grey">No Submission</span>
@@ -143,7 +150,7 @@
   <div class="subcontent list hidden-md hidden-lg">
     <div class="wrap">
       <h2>{{ tname }}</h2>
-      {% for assign, subm_time, group, fs, scores in assignments %}
+      {% for assign, subm_time, group, fs, scores, latest_backup in assignments %}
       <div class="cell col-xs-12">
         <div class="cell-title">
           <a class="dashed" href="{{ url_for('.assignment', name=assign.name)}}">


### PR DESCRIPTION
This adds a column for the latest backup to the staff view. 

Performance: also means that we are doing an extra query on the student side - but I didn't think it was worth it to only add this for staff (based on the `is_staff` argument) 

Usage: Easier to link from Office Hours app to this page 