### PR TITLE
fixes #885: renders comments below composition score

### DIFF
--- a/server/templates/diff.html
+++ b/server/templates/diff.html
@@ -3,9 +3,9 @@
   <td class="line-number" data-line-number="{{ '' if i is none else i }}"></td>
 {% endmacro %}
 
-{% macro render_comment(comment, linkable_id=True) %}
+{% macro render_comment(comment) %}
   <div class="comment"
-    {% if linkable_id %} id="{{ utils.encode_id(comment.id) }}" {% endif %} 
+    id="{{ utils.encode_id(comment.id) }}" 
     data-id="{{ utils.encode_id(comment.id) }}"
     data-message="{{ comment.message }}"
     data-no-instant>

--- a/server/templates/diff.html
+++ b/server/templates/diff.html
@@ -3,8 +3,9 @@
   <td class="line-number" data-line-number="{{ '' if i is none else i }}"></td>
 {% endmacro %}
 
-{% macro render_comment(comment) %}
+{% macro render_comment(comment, linkable_id=True) %}
   <div class="comment"
+    {% if linkable_id %} id="{{ utils.encode_id(comment.id) }}" {% endif %} 
     data-id="{{ utils.encode_id(comment.id) }}"
     data-message="{{ comment.message }}"
     data-no-instant>

--- a/server/templates/student/assignment/code.html
+++ b/server/templates/student/assignment/code.html
@@ -34,9 +34,12 @@
                     {% else %}
                     <pre class="score-box">{{ score.message }}</pre>
                     {% endif %}
-                {% endfor %}
-              {% endif %}
 
+                    {% if score.kind == "composition" %}
+                        {% include 'student/assignment/list_comments.html' %}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
           </div>
           {% include 'alerts.html' %}
         </div>

--- a/server/templates/student/assignment/list_comments.html
+++ b/server/templates/student/assignment/list_comments.html
@@ -1,19 +1,31 @@
 {% import 'diff.html' as diff with context %}
 {% if assignment.files %}
-    {% if self.comments() | trim %}
-        <h2 class="label label-info">Grader's comments:</h2>
-        <ul class="list-group">
+  {% if self.comments() | trim %}
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th>Location</th>
+          <th>Comment</th>
+        </tr>
+      </thead>
+      <tbody>
         {% block comments %}
-            {% for filename, file in files | dictsort %}
-                {% for line in file.lines if line.comments %}
-                    {% for comment in line.comments if comment.author.email == score.grader.email %}
-                        <a href="#{{ utils.encode_id(comment.id) }}" class="list-group-item list-group-action">
-                            {{ filename }} at line {{ line.line_after }}: {{ comment.message | truncate(70) }}
-                        </a>
-                    {% endfor %}
-                {% endfor %}
+          {% for filename, file in files | dictsort %}
+            {% for line in file.lines if line.comments %}
+              {% for comment in line.comments if comment.author.email == score.grader.email %}
+                <tr>
+                  <td>
+                    <a href="#{{ utils.encode_id(comment.id) }}">
+                      {{ filename }} on line {{ line.line_after }}
+                    </a>
+                  </td>
+                  <td>{{ comment.message | truncate(70) }}</td>
+                </tr>
+              {% endfor %}
             {% endfor %}
+          {% endfor %}
         {% endblock %}
-        </ul>
-    {% endif %}
+      </tbody>
+    </table>
+  {% endif %}
 {% endif %}

--- a/server/templates/student/assignment/list_comments.html
+++ b/server/templates/student/assignment/list_comments.html
@@ -6,13 +6,14 @@
         <tr>
           <th>Location</th>
           <th>Comment</th>
+          <th>Commenter</th>
         </tr>
       </thead>
       <tbody>
         {% block comments %}
           {% for filename, file in files | dictsort %}
             {% for line in file.lines if line.comments %}
-              {% for comment in line.comments if comment.author.email == score.grader.email %}
+              {% for comment in line.comments %}
                 <tr>
                   <td>
                     <a href="#{{ utils.encode_id(comment.id) }}">
@@ -20,6 +21,7 @@
                     </a>
                   </td>
                   <td>{{ comment.message | truncate(70) }}</td>
+                  <td>{{ comment.author.identifier }}</td>
                 </tr>
               {% endfor %}
             {% endfor %}

--- a/server/templates/student/assignment/list_comments.html
+++ b/server/templates/student/assignment/list_comments.html
@@ -8,8 +8,7 @@
                 {% for line in file.lines if line.comments %}
                     {% for comment in line.comments if comment.author.email == score.grader.email %}
                         <a href="#{{ utils.encode_id(comment.id) }}" class="list-group-item list-group-action">
-                            <h4 class="list-group-item-heading">File {{ filename }}, line {{ line.line_after }}.</h4>
-                            <span class="list-group-item-text">{{ diff.render_comment(comment, False) }}</span>
+                            {{ filename }} at line {{ line.line_after }}: {{ comment.message | truncate(70) }}
                         </a>
                     {% endfor %}
                 {% endfor %}

--- a/server/templates/student/assignment/list_comments.html
+++ b/server/templates/student/assignment/list_comments.html
@@ -1,0 +1,20 @@
+{% import 'diff.html' as diff with context %}
+{% if assignment.files %}
+    {% if self.comments() | trim %}
+        <h2 class="label label-info">Grader's comments:</h2>
+        <ul class="list-group">
+        {% block comments %}
+            {% for filename, file in files | dictsort %}
+                {% for line in file.lines if line.comments %}
+                    {% for comment in line.comments if comment.author.email == score.grader.email %}
+                        <a href="#{{ utils.encode_id(comment.id) }}" class="list-group-item list-group-action">
+                            <h4 class="list-group-item-heading">File {{ filename }}, line {{ line.line_after }}.</h4>
+                            <span class="list-group-item-text">{{ diff.render_comment(comment, False) }}</span>
+                        </a>
+                    {% endfor %}
+                {% endfor %}
+            {% endfor %}
+        {% endblock %}
+        </ul>
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
This commit displays all comments written by the grader below the
composition score. Clicking on a comment brings the student to the
line where the comment was written. The template logic is handled in
student/assignment/list_comments.html. Changes were also made to
diff.html in order to make the comments linkable with href anchors.

I don't particularly like adding the second argument to
render_comment in diff.html, but its necessary in order to make sure
that each ID occurs only once (because I used render_comment) to
render the comments twice.

Also a lot of the logic is handled in the list_comments template,
and some of that might be better rewritten in Python. I think that
its simple enough to not be a problem right now.

Here is an example of how it looks. I'm open to changing the exact
design.

![example](https://cloud.githubusercontent.com/assets/22647613/20551930/83c18344-b0fa-11e6-894e-8cdc633e93c7.png)
