### PR TITLE
CSV with highest score per Score Kind

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -551,7 +551,7 @@ def export_scores(cid, aid):
 
 @admin.route("/course/<int:cid>/assignments/<int:aid>/scores_max")
 @is_staff(course_arg='cid')
-def export_scores(cid, aid):
+def export_max_scores(cid, aid):
     courses, current_course = get_courses(cid)
     assign = Assignment.query.filter_by(id=aid, course_id=cid).one_or_none()
     if not Assignment.can(assign, current_user, 'export'):
@@ -562,7 +562,7 @@ def export_scores(cid, aid):
 
     custom_items = ('time', 'is_late', 'email', 'group')
     items = custom_items + Enrollment.export_items + Score.export_items
-    highest_seen_score = defaultdict(lambda: defaultdict(lambda: float("-inf")))
+    highest_seen_score = collections.defaultdict(lambda: collections.defaultdict(lambda: float("-inf")))
     # Submitter -> Score Kind -> Highest Score 
 
     def generate_csv():

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -703,7 +703,8 @@ def start_moss_job(cid, aid):
             assignment_id=assign.id,
             moss_id=form.moss_userid.data,
             file_regex=form.file_regex.data or '*',
-            language=form.language.data)
+            language=form.language.data,
+            subtract_template=form.subtract_template.data)
         return redirect(url_for('.course_job', cid=cid, job_id=job.id))
     else:
         return render_template(

--- a/server/forms.py
+++ b/server/forms.py
@@ -431,7 +431,6 @@ class PublishScores(BaseForm):
         choices=[(kind, kind.title()) for kind in SCORE_KINDS],
     )
 
-
 ########
 # Jobs #
 ########
@@ -446,6 +445,8 @@ class MossSubmissionForm(BaseForm):
     file_regex = StringField('Regex for submitted files', default='.*',
                              validators=[validators.required()])
     language = SelectField('Language', choices=[(pl, pl) for pl in COMMON_LANGUAGES])
+    subtract_template = BooleanField('Subtract Template', default=False,
+                                     description="Only send the changes from the template to MOSS")
 
 class GithubSearchRecentForm(BaseForm):
     access_token = StringField('Github Access Token',

--- a/server/templates/staff/jobs/moss.html
+++ b/server/templates/staff/jobs/moss.html
@@ -36,6 +36,7 @@
             {{ forms.render_field(form.moss_userid) }}
             {{ forms.render_field(form.file_regex, default=".*") }}
             {{ forms.render_field(form.language) }}
+            {{ forms.render_checkbox_field(form.subtract_template) }}
             {% endcall %}
         </div>
       </div>


### PR DESCRIPTION
This needs work - this is just a hacky prototype for a course request. (also there are some commits I need to get out of this branch) 

I'd like to see this be the default download and the current one (which gets all scores) become the secondary one 

We might want to keep the same endpoint but we'll just use request args 

`..../scores` -> One with the highest score per person per score kind 
`..../scores?all=1` -> All Scores 
