### PR TITLE
Use maintained fork of Flask-Cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ WTForms>=2.0,<3.0
 
 # Flask Extensions
 Flask-Assets>=0.12,<0.12.99
-Flask-Cache==0.13.1
+Flask-Caching>=1.1
 Flask-Login==0.3.2
 
 # OAuth

--- a/server/extensions.py
+++ b/server/extensions.py
@@ -1,4 +1,4 @@
-from flask_cache import Cache
+from flask_caching import Cache
 from flask_wtf.csrf import CsrfProtect
 from flask_debugtoolbar import DebugToolbarExtension
 from flask_assets import Environment


### PR DESCRIPTION
Found Flask-Caching while working on another project. 

It's a maintained fork of Flask-Cache (that's API compatible). Flask-Cache hasn't been updated in 2+ years - which is mildly concerning. 

The only side effect right now is that we get once less `ExtDeprecationWarning` when launching the app. (The other one is from Flask-DebugToolbar - which just hasn't deployed the latest version to PyPi yet)

