### PR TITLE
Logging to Google Stackdriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,13 @@ RUN mv docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 
 RUN ./manage.py assets build
 
-CMD nginx; gunicorn --timeout 45 --bind unix:/tmp/server.sock wsgi:app --workers 3
+CMD nginx && \
+    env PYTHONPATH=$PYTHONPATH:$PWD gunicorn \
+        --logger-class server.logging.gunicorn.Logger \
+        --timeout 45 \
+        --bind unix:/tmp/server.sock \
+        --workers 3 \
+        wsgi:app
 
 RUN rm -rf /var/cache/apk/*
 

--- a/kubernetes/ok-staging-direct.yaml
+++ b/kubernetes/ok-staging-direct.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ok-staging-web-lb
+  name: ok-staging-direct
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
     - port: 80
+      nodePort: 30402
       targetPort: 5000
   selector:
     app: staging

--- a/kubernetes/ok-staging-ingress.yaml
+++ b/kubernetes/ok-staging-ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ok-staging-ingress
+spec:
+  backend:
+    serviceName: ok-staging-direct
+    servicePort: 80

--- a/kubernetes/ok-staging-web-rc.yaml
+++ b/kubernetes/ok-staging-web-rc.yaml
@@ -20,7 +20,7 @@ spec:
         livenessProbe:
           # an http probe
           httpGet:
-            path: /
+            path: /healthz
             port: 5000
           initialDelaySeconds: 5
           timeoutSeconds: 1

--- a/kubernetes/ok-staging-web-rc.yaml
+++ b/kubernetes/ok-staging-web-rc.yaml
@@ -18,7 +18,12 @@ spec:
         image: cs61a/ok-server
         imagePullPolicy: Always
         livenessProbe:
-          # an http probe
+          httpGet:
+            path: /healthz
+            port: 5000
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        readinessProbe:
           httpGet:
             path: /healthz
             port: 5000

--- a/kubernetes/ok-staging-web-rc.yaml
+++ b/kubernetes/ok-staging-web-rc.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: ok-v3-staging
-        image: cs61a/ok-server:v3.2.28
+        image: cs61a/ok-server
         imagePullPolicy: Always
         livenessProbe:
           # an http probe
@@ -73,3 +73,5 @@ spec:
             secretKeyRef:
               name: ok-services
               key: sendgrid-key
+        - name: GOOGLE_LOG_NAME
+          value: ok-staging

--- a/kubernetes/ok-web-deployment.yaml
+++ b/kubernetes/ok-web-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         livenessProbe:
           # an http probe
           httpGet:
-            path: /
+            path: /healthz
             port: 5000
           initialDelaySeconds: 5
           timeoutSeconds: 1

--- a/kubernetes/ok-web-deployment.yaml
+++ b/kubernetes/ok-web-deployment.yaml
@@ -18,7 +18,12 @@ spec:
         image: cs61a/ok-server
         imagePullPolicy: Always
         livenessProbe:
-          # an http probe
+          httpGet:
+            path: /healthz
+            port: 5000
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        readinessProbe:
           httpGet:
             path: /healthz
             port: 5000

--- a/kubernetes/ok-web-deployment.yaml
+++ b/kubernetes/ok-web-deployment.yaml
@@ -73,3 +73,5 @@ spec:
             secretKeyRef:
               name: ok-services
               key: sendgrid-key
+        - name: GOOGLE_LOG_NAME
+          value: ok-web

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,9 @@ markdown>=2.6,<2.7
 pygal>=2.3,<2.4
 bleach==1.5.0
 
+# Logging
+gcloud==0.18.3
+
 # Development
 Flask-DebugToolbar==0.10.0
 Flask-Script==2.0.5

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,5 +1,4 @@
 import os
-import logging
 
 from flask import Flask, render_template, g, request
 from flask_rq import RQ
@@ -7,7 +6,7 @@ from flask_wtf.csrf import CsrfProtect
 from webassets.loaders import PythonLoader as PythonAssetsLoader
 from werkzeug.contrib.fixers import ProxyFix
 
-from server import assets, converters, utils
+from server import assets, converters, logging, utils
 from server.forms import CSRFForm
 from server.models import db
 from server.controllers.about import about
@@ -59,10 +58,6 @@ def create_app(default_config_path=None):
                     public_dsn=sentry.client.get_public_dsn('https')
                 ), 500
 
-        # In production mode, add log handler to sys.stderr.
-        app.logger.addHandler(logging.StreamHandler())
-        app.logger.setLevel(logging.INFO)
-
     @app.errorhandler(404)
     def not_found_error(error):
         if request.path.startswith("/api"):
@@ -87,6 +82,9 @@ def create_app(default_config_path=None):
 
     # Flask-Login manager
     login_manager.init_app(app)
+
+    # Set up logging
+    logging.init_app(app)
 
     # Import and register the different asset bundles
     assets_env.init_app(app)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -64,6 +64,10 @@ def create_app(default_config_path=None):
             return api.handle_error(error)
         return render_template('errors/404.html'), 404
 
+    @app.route("/healthz")
+    def health_check():
+        return 'OK'
+
     # initialize the cache
     cache.init_app(app)
 

--- a/server/logging/__init__.py
+++ b/server/logging/__init__.py
@@ -1,0 +1,35 @@
+import logging
+
+from flask import request
+
+REQUEST_LOG_VARIABLE = 'okpy.log'
+
+class RequestLog:
+    def __init__(self):
+        self.endpoint = request.url_rule and request.url_rule.endpoint
+        self.lines = []
+
+class RequestLogHandler(logging.Handler):
+    """A log handler that attaches logs to the WSGI request environment."""
+    def handle(self, record):
+        try:
+            request_log = request.environ[REQUEST_LOG_VARIABLE]
+        except (RuntimeError, KeyError):
+            # We're outside of a request context. This could happen if something
+            # else tries to use a Python logger, like gunicorn or compiling
+            # assets
+            return
+        request_log.lines.append(record)
+
+def init_app(app):
+    if app.debug:
+        return
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(RequestLogHandler())
+    app.logger.propagate = True
+
+    @app.before_request
+    def start_request_log():
+        request.environ[REQUEST_LOG_VARIABLE] = RequestLog()

--- a/server/logging/__init__.py
+++ b/server/logging/__init__.py
@@ -1,6 +1,9 @@
 import logging
 
 from flask import request
+from flask_login import current_user
+
+logger = logging.getLogger(__name__)
 
 REQUEST_LOG_VARIABLE = 'okpy.log'
 
@@ -33,3 +36,7 @@ def init_app(app):
     @app.before_request
     def start_request_log():
         request.environ[REQUEST_LOG_VARIABLE] = RequestLog()
+
+        # Log info about every request
+        if current_user.is_authenticated:
+            logger.info('User: %s', current_user.email)

--- a/server/logging/gunicorn.py
+++ b/server/logging/gunicorn.py
@@ -28,7 +28,7 @@ class ProcessCloudLogger:
     def __init__(self):
         self.logger_pid = None
         self.logger = None
-        self.log_name = os.environ.get('GOOGLE_LOG_NAME', 'unknown')
+        self.log_name = os.environ.get('GOOGLE_LOG_NAME', 'ok-default')
 
     def get_instance(self):
         pid = os.getpid()

--- a/server/logging/gunicorn.py
+++ b/server/logging/gunicorn.py
@@ -1,0 +1,124 @@
+import datetime
+import json
+import logging
+import os
+import traceback
+
+import gcloud.logging
+from google.protobuf.json_format import ParseDict
+from google.protobuf.struct_pb2 import Struct
+import gunicorn.glogging
+
+from server.logging import REQUEST_LOG_VARIABLE
+
+ACCESS_LOG_FORMAT = '%(message)s (%(pathname)s:%(lineno)d, in %(funcName)s)'
+ERROR_LOG_FORMAT = '[gunicorn] %(message)s'
+
+access_formatter = logging.Formatter(ACCESS_LOG_FORMAT)
+error_formatter = logging.Formatter(ERROR_LOG_FORMAT)
+
+def format_time(dt):
+    """Formats a naive datetime as UTC time"""
+    return dt.isoformat() + 'Z'
+
+class ProcessCloudLogger:
+    """Call get_logger() to get a Google Cloud logger instance. Ensures that
+    each process has its own logger.
+    """
+    def __init__(self):
+        self.logger_pid = None
+        self.logger = None
+        self.log_name = os.environ.get('GOOGLE_LOG_NAME', 'unknown')
+
+    def get_instance(self):
+        pid = os.getpid()
+        if self.logger_pid != pid:
+            self.logger_pid = pid
+            client = gcloud.logging.Client()
+            self.logger = client.logger(self.log_name)
+        return self.logger
+
+    def log_proto(self, *args, **kwargs):
+        try:
+            self.get_instance().log_proto(*args, **kwargs)
+        except Exception:
+            traceback.print_exc()
+            traceback.print_exc()
+
+    def log_struct(self, *args, **kwargs):
+        try:
+            self.get_instance().log_struct(*args, **kwargs)
+        except Exception:
+            traceback.print_exc()
+
+    def log_text(self, *args, **kwargs):
+        try:
+            self.get_instance().log_text(*args, **kwargs)
+        except Exception:
+            traceback.print_exc()
+
+class GoogleCloudHandler(logging.Handler):
+    def __init__(self, cloud_logger):
+        super().__init__()
+        self.cloud_logger = cloud_logger
+
+    def handle(self, record):
+        message = error_formatter.format(record)
+        self.cloud_logger.log_text(message, severity=record.levelname)
+
+class Logger(gunicorn.glogging.Logger):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cloud_logger = ProcessCloudLogger()
+        self.error_log.addHandler(GoogleCloudHandler(self.cloud_logger))
+
+    def access(self, resp, req, environ, request_time):
+        super().access(resp, req, environ, request_time)
+
+        # See gunicorn/glogging.py
+        status = resp.status
+        if isinstance(status, str):
+            status = status.split(None, 1)[0]
+        now = datetime.datetime.utcnow()
+
+        level = logging.NOTSET
+        message = {
+            '@type': 'type.googleapis.com/google.appengine.logging.v1.RequestLog',
+            'ip': environ.get('REMOTE_ADDR'),
+            'startTime': format_time(now - request_time),
+            'endTime': format_time(now),
+            'latency': '%d.%06ds' % (request_time.seconds, request_time.microseconds),
+            'method': environ['REQUEST_METHOD'],
+            'resource': environ['PATH_INFO'],
+            'httpVersion': environ['SERVER_PROTOCOL'],
+            'status': status,
+            'responseSize': getattr(resp, 'sent', None),
+            'userAgent': environ.get('HTTP_USER_AGENT'),
+        }
+
+        request_log = environ.get(REQUEST_LOG_VARIABLE)
+        if request_log:
+            message['urlMapEntry'] = request_log.endpoint
+            message['line'] = [
+                {
+                    'time': format_time(datetime.datetime.utcfromtimestamp(record.created)),
+                    'severity': record.levelname,
+                    'logMessage': access_formatter.format(record),
+                    # The log viewer only wants real App Engine files, so we
+                    # can't put the actual file here.
+                    'sourceLocation': None,
+                }
+                for record in request_log.lines
+            ]
+            level = max(
+                (record.levelno for record in request_log.lines),
+                default=logging.NOTSET,
+            )
+
+        if level > logging.NOTSET:
+            severity = logging.getLevelName(level)
+        else:
+            severity = None
+
+        struct_pb = ParseDict(message, Struct())
+        self.cloud_logger.log_proto(struct_pb, severity=severity)

--- a/server/logging/gunicorn.py
+++ b/server/logging/gunicorn.py
@@ -75,6 +75,10 @@ class Logger(gunicorn.glogging.Logger):
     def access(self, resp, req, environ, request_time):
         super().access(resp, req, environ, request_time)
 
+        # Ignore health check
+        if environ['PATH_INFO'] == '/healthz':
+            return
+
         # See gunicorn/glogging.py
         status = resp.status
         if isinstance(status, str):

--- a/server/settings/prod.py
+++ b/server/settings/prod.py
@@ -3,19 +3,13 @@
 """
 import os
 import sys
-import binascii
 
 from server.settings import RAVEN_IGNORE_EXCEPTIONS
-
-default_secret = binascii.hexlify(os.urandom(24))
 
 ENV = 'prod'
 PREFERRED_URL_SCHEME = 'https'
 
-if not os.getenv('SECRET_KEY'):
-    print("The secret key is not set!!")
-
-SECRET_KEY = os.getenv('SECRET_KEY', default_secret)
+SECRET_KEY = os.getenv('SECRET_KEY')
 
 DEBUG = False
 ASSETS_DEBUG = False

--- a/server/settings/prod.py
+++ b/server/settings/prod.py
@@ -15,6 +15,11 @@ DEBUG = False
 ASSETS_DEBUG = False
 TESTING_LOGIN = False
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+# The Google Cloud load balancer behaves like two proxies: one with the external
+# fowarding rule IP, and one with an internal IP.
+# See https://cloud.google.com/compute/docs/load-balancing/http/#target_proxies
+# Including Nginx too makes 3 proxies.
+NUM_PROXIES = 3
 
 db_url = os.getenv('DATABASE_URL')
 if db_url:

--- a/server/settings/simple.py
+++ b/server/settings/simple.py
@@ -3,19 +3,13 @@
 """
 import os
 import sys
-import binascii
 
 from server.settings import RAVEN_IGNORE_EXCEPTIONS
-
-default_secret = binascii.hexlify(os.urandom(24))
 
 ENV = 'simple'
 PREFERRED_URL_SCHEME = 'http'
 
-if not os.getenv('SECRET_KEY'):
-    print("The secret key is not set!!")
-
-SECRET_KEY = os.getenv('SECRET_KEY', default_secret)
+SECRET_KEY = os.getenv('SECRET_KEY')
 
 DEBUG = False
 ASSETS_DEBUG = False

--- a/server/settings/staging.py
+++ b/server/settings/staging.py
@@ -3,16 +3,14 @@
 """
 import os
 import sys
-import binascii
 
 from server.settings import RAVEN_IGNORE_EXCEPTIONS
-
-default_secret = binascii.hexlify(os.urandom(24))
 
 ENV = 'staging'
 PREFERRED_URL_SCHEME = 'https'
 
-SECRET_KEY = os.getenv('SECRET_KEY', default_secret)
+SECRET_KEY = os.getenv('SECRET_KEY')
+
 CACHE_TYPE = 'simple'
 
 DEBUG = False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,3 +6,8 @@ class TestMain(OkTestCase):
         response = self.client.get('/')
         self.assert_200(response)
         self.assert_template_used('index.html')
+
+    def test_health_check(self):
+        """Tests that the health check is successful."""
+        response = self.client.get('/healthz')
+        self.assert_200(response)


### PR DESCRIPTION
Resolves #802.

We use a custom gunicorn logger class that logs to Google cloud using their client library. This requires setting `PYTHONPATH` and passing in the custom logger module on the command line. The environment variable `GOOGLE_LOG_NAME` sets the log name.

The access log forges the App Engine log format so the logs viewer shows it nicely. Logs from the application are collected on the WSGI environ object and passed back to gunicorn. This includes stack traces for uncaught exceptions. The error log (which includes gunicorn info) is written straight with minimal formatting.

If an error occurs while writing log entries, the exception is printed to stderr. I'm not too sure what to do in this case.

Test by setting `DEBUG` = False in `server/settings/dev.py` and running `env GOOGLE_LOG_NAME=knrafto-test-log PYTHONPATH=$PYTHONPATH:$PWD gunicorn --logger-class server.logging.gunicorn.Logger --bind 127.0.0.1:5000 --workers 3 wsgi:app`. Play around and look at the logs. They'll be under Global > knrafto-test-log in the logs viewer.

The kubernetes health checks are very spammy. One solution would be to have a separate endpoint for the health check (that just returns 200), and filter that out before we ship the log. Should that happen in this PR?