### PR TITLE
Do not use string formatting for URL generation, even in jobs

### DIFF
--- a/server/jobs/example.py
+++ b/server/jobs/example.py
@@ -1,5 +1,7 @@
 import time
 
+from flask import url_for
+
 from server import jobs
 from server.models import ExternalFile
 from server.utils import encode_id
@@ -21,8 +23,8 @@ def test_job(duration=0, should_fail=False, make_file=False):
                                      name='temp.okfile', prefix='jobs/example/')
         logger.info("Saved as: {}".format(upload.object_name))
         logger.info('File ID: {0}'.format(encode_id(upload.id)))
-        msg = ("Waited for <a href='/files/{0}'> {1} seconds </a>"
-               .format(encode_id(upload.id), duration))
+        msg = ("Waited for <a href='{0}'> {1} seconds </a>"
+               .format(url_for('files.file_url', file_id=upload.id), duration))
     else:
         msg = "Waited for <b>{}</b> seconds!".format(duration)
     logger.info('Finished!')

--- a/server/models.py
+++ b/server/models.py
@@ -1683,10 +1683,6 @@ class ExternalFile(Model):
             return 'application/octet-stream'
         return guess[0]
 
-    @property
-    def download_link(self):
-        return '/files/{}'.format(encode_id(self.id))
-
     def delete(self):
         self.object().delete()
         self.deleted = True


### PR DESCRIPTION
This is mostly a response to [this comment](https://github.com/Cal-CS-61A-Staff/ok/pull/1046#discussion_r98144227): workers have an app context, so we should use url_for in jobs as well instead of string formatting.