### PR TITLE
Use our own build of markdown-it-anchor due to wzrd.in instability

### DIFF
--- a/server/assets.py
+++ b/server/assets.py
@@ -39,7 +39,7 @@ common_js = Bundle(
     'https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.min.js',
     'https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.0.1/markdown-it.js',
     'https://cdn.rawgit.com/svbergerem/markdown-it-sanitizer/6efc1722/dist/markdown-it-sanitizer.js',
-    'https://wzrd.in/standalone/markdown-it-anchor@2.6.0',
+    'https://cdn.rawgit.com/okpy/markdown-it-anchor/722f7a89/dist/markdown-it-anchor.js',
     'https://cdn.ravenjs.com/2.1.0/raven.js',
     'js/main.js',
     filters='jsmin',


### PR DESCRIPTION
It works: http://ok-staging.cs61a.org/admin/grading/dP0qgA

I forked the repo to https://github.com/okpy/markdown-it-anchor and added an npm script that will run browserify. I prefer this to committing the build file into this repo because it should be easy to pull and rebuild if the upstream markdown-it-anchor changes.