### PR TITLE
HTTPS by default

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -37,6 +37,8 @@ server {
       }
 
       proxy_set_header X-Forwarded-Proto https;
+      add_header Strict-Transport-Security "max-age=3600; includeSubdomains" always;
+
       proxy_set_header Host $http_host;
       # we don't want nginx trying to do something clever with
       # redirects, we set the Host: header above already.

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -25,10 +25,8 @@ server {
         if ($http_x_forwarded_proto = "http") {
             return 301 https://$host$request_uri;
         }
-        if ($http_x_forwarded_proto = "https") {
-            add_header Strict-Transport-Security "max-age=3600;" always;
-            # Send STS only over SSL https://tools.ietf.org/html/rfc6797 7.2
-        }
+
+        add_header Strict-Transport-Security "max-age=3600;" always;
 
         include  /etc/nginx/mime.types;
         sendfile        on;
@@ -41,10 +39,8 @@ server {
       if ($http_x_forwarded_proto = "http") {
          return 301 https://$host$request_uri;
       }
-      if ($http_x_forwarded_proto = "https") {
-         add_header Strict-Transport-Security "max-age=3600;" always;
-         # Send STS only over SSL https://tools.ietf.org/html/rfc6797 7.2
-      }
+
+      add_header Strict-Transport-Security "max-age=3600;" always;
 
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Nginx-IP $remote_addr;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -22,6 +22,14 @@ server {
     send_timeout                300;
 
     location /static/ {
+        if ($http_x_forwarded_proto = "http") {
+            return 301 https://$host$request_uri;
+        }
+        if ($http_x_forwarded_proto = "https") {
+            add_header Strict-Transport-Security "max-age=3600;" always;
+            # Send STS only over SSL https://tools.ietf.org/html/rfc6797 7.2
+        }
+
         include  /etc/nginx/mime.types;
         sendfile        on;
         root /code/server/;
@@ -29,13 +37,14 @@ server {
 
     location / {
       # enable this if and only if you use HTTPS
-      if ($http_x_forwarded_proto = "http") {
-        return 301 https://$host$request_uri;
-      } else {
-        add_header Strict-Transport-Security "max-age=3600;" always;
-        # Send STS only over SSL https://tools.ietf.org/html/rfc6797 7.2
-      }
 
+      if ($http_x_forwarded_proto = "http") {
+         return 301 https://$host$request_uri;
+      }
+      if ($http_x_forwarded_proto = "https") {
+         add_header Strict-Transport-Security "max-age=3600;" always;
+         # Send STS only over SSL https://tools.ietf.org/html/rfc6797 7.2
+      }
 
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Nginx-IP $remote_addr;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -28,16 +28,20 @@ server {
     }
 
     location / {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Nginx-IP $remote_addr;
-
       # enable this if and only if you use HTTPS
       if ($http_x_forwarded_proto = "http") {
         return 301 https://$host$request_uri;
+      } else {
+        add_header Strict-Transport-Security "max-age=3600;" always;
+        # Send STS only over SSL https://tools.ietf.org/html/rfc6797 7.2
       }
 
-      proxy_set_header X-Forwarded-Proto https;
-      add_header Strict-Transport-Security "max-age=3600; includeSubdomains" always;
+
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Nginx-IP $remote_addr;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
+      add_header X-Frame-Options "SAMEORIGIN";
 
       proxy_set_header Host $http_host;
       # we don't want nginx trying to do something clever with

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -32,8 +32,11 @@ server {
       proxy_set_header X-Nginx-IP $remote_addr;
 
       # enable this if and only if you use HTTPS
+      if ($http_x_forwarded_proto = "http") {
+        return 301 https://$host$request_uri;
+      }
 
-      # proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Proto https;
       proxy_set_header Host $http_host;
       # we don't want nginx trying to do something clever with
       # redirects, we set the Host: header above already.


### PR DESCRIPTION
All requests are made over SSL 

Tested in staging (and briefly in production - by accident 😱). HSTS works as expected. 

There's a low HSTS value. It should be at least 90 days. We can bump it once we roll this out and don't see too many issues. 

This is possible thanks to ok-client using requests with bundled SSL certs. Ok Client's `--insecure` flag should now only be used for development. 

