### PR TITLE
Remove Pace.js

### DIFF
--- a/server/assets.py
+++ b/server/assets.py
@@ -48,14 +48,12 @@ common_js = Bundle(
 
 dropzone_css = Bundle(
     'https://cdnjs.cloudflare.com/ajax/libs/dropzone/4.3.0/dropzone.css',
-    'https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/themes/blue/pace-theme-loading-bar.css',
     'css/dropzone.css',
     filters='cssmin',
     output='public/css/dropzone.css'
 )
 dropzone_js = Bundle(
     'https://cdnjs.cloudflare.com/ajax/libs/dropzone/4.3.0/dropzone.js',
-    'https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.js',
     'js/dropzone.js',
     filters='jsmin',
     output='public/js/dropzone.js'

--- a/server/static/js/dropzone.js
+++ b/server/static/js/dropzone.js
@@ -22,9 +22,7 @@ function initDropzone(elem, token) {
             var myDropzone = this; // reference for closure
 
             submitButton.addEventListener("click", function() {
-                Pace.track( function () {
-                    myDropzone.processQueue(); // Tell Dropzone to process all queued files.
-                });
+                myDropzone.processQueue(); // Tell Dropzone to process all queued files.
             })
 
             this.on("addedfile", function(file) {

--- a/server/static/js/main.js
+++ b/server/static/js/main.js
@@ -1,14 +1,3 @@
-window.paceOptions = {
-  startOnPageLoad: false,
-  ajax: {
-    trackMethods: ['GET', 'POST', 'DELETE', 'PUT'],
-    trackWebSockets: true,
-    ignoreURLs: []
-  },
-  restartOnPushState: false,
-  eventLag: false // disabled
-};
-
 if (typeof HTMLElement.prototype.removeClass !== "function") {
     HTMLElement.prototype.removeClass = function(remove) {
         var newClassName = "";


### PR DESCRIPTION
Pace.js basically amounted to a fake progress bar for file uploads. I added it because I thought it would be more effective than the a swal with a loader gif. 

After #1058, the progress bar seen in dropzone.js is more or less accurate. Whether or not we should remove the sweetalert loading alert is now also worth debate 

Example of Pace vs dropzone:  
![image](https://cloud.githubusercontent.com/assets/882381/22624848/92829928-eb3c-11e6-9c61-8a162e7fcec2.png)

sweetalert example:
![image](https://cloud.githubusercontent.com/assets/882381/22624853/b9297e02-eb3c-11e6-8fff-1124da410461.png)

For now I'm going with keeping the sweetalert since it really makes it clear that users should wait. The downside is that the alert can obscure the accurate progress bars 