### PR TITLE
Do not use gunicorn threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ CMD nginx && \
     env PYTHONPATH=$PYTHONPATH:$PWD gunicorn \
         --logger-class server.logging.gunicorn.Logger \
         --timeout 60 \
-        --threads 2 \
         --bind unix:/tmp/server.sock \
         --workers 3 \
         wsgi:app


### PR DESCRIPTION
The Google Cloud library we use for logging uses the httplib2 library, which is not thread-safe. We're seeing some crashes and we're not sure if this caused it, but we're removing it to be safe. It's no longer necessary due to #1058.

We should keep this in mind when we implement async workers (#1031). The Google Cloud library allows us to use a custom HTTP library, so maybe we should look in to that.