### PR TITLE
Autograding job

### DIFF
--- a/server/autograder.py
+++ b/server/autograder.py
@@ -25,6 +25,8 @@ def send_autograder(endpoint, data):
                       data=json.dumps(data), headers=headers, timeout=8)
 
     if r.status_code == requests.codes.ok:
+        if r.text == "OK":  # e.g. when the token is "test"
+            return {}
         return r.json()
     else:
         error_message = 'The autograder rejected your request. {0}'.format(
@@ -78,7 +80,7 @@ def send_batch(token, assignment, backup_ids, priority='default'):
 def autograde_backup(token, assignment, backup_id):
     """Autograde a backup, returning and autograder job ID."""
     jobs = send_batch(token, assignment, [backup_id], priority='high')
-    return jobs[backup_id]
+    return jobs.get(backup_id)
 
 def submit_continous(backup):
     """ Intended for continous grading (email with results on submit)

--- a/server/autograder.py
+++ b/server/autograder.py
@@ -4,7 +4,6 @@ This module interfaces the OK Server with Autopy. The actual autograding happens
 in a sandboxed environment.
 """
 
-from flask import url_for
 from flask_login import current_user
 import datetime
 import json
@@ -70,7 +69,6 @@ def send_batch(assignment, backup_ids, priority='default'):
         'assignment': assignment.autograding_key,
         'access_token': token.access_token,
         'priority': priority,
-        'backup_url': url_for('api.backup', _external=True),
         'ok-server-version': 'v3',
     })
     return dict(zip(backup_ids, response_json['jobs']))

--- a/server/autograder.py
+++ b/server/autograder.py
@@ -26,7 +26,7 @@ def send_autograder(endpoint, data):
 
     if r.status_code == requests.codes.ok:
         if r.text == "OK":  # e.g. when the token is "test"
-            return {}
+            return None
         return r.json()
     else:
         error_message = 'The autograder rejected your request. {0}'.format(
@@ -75,8 +75,11 @@ def send_batch(token, assignment, backup_ids, priority='default'):
         'priority': priority,
         'ok-server-version': 'v3',
     })
-    return dict(zip(backup_ids, response_json['jobs']))
-
+    if response_json:
+        return dict(zip(backup_ids, response_json['jobs']))
+    else:
+        return {}
+    
 def autograde_backup(token, assignment, backup_id):
     """Autograde a backup, returning and autograder job ID."""
     jobs = send_batch(token, assignment, [backup_id], priority='high')

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -675,11 +675,14 @@ def autograde(cid, aid):
         return abort(404)
     form = forms.CSRFForm()
     if form.validate_on_submit():
-        try:
-            autograder.autograde_assignment(assign)
-            flash('Submitted to the autograder', 'success')
-        except ValueError as e:
-            flash(str(e), 'error')
+        job = jobs.enqueue_job(
+            autograder.autograde_assignment,
+            description='Autograde {}'.format(assign.display_name),
+            timeout=1800,
+            course_id=cid,
+            user_id=current_user.id,
+            assignment_id=assign.id)
+        return redirect(url_for('.course_job', cid=cid, job_id=job.id))
     return redirect(url_for('.assignment', cid=cid, aid=aid))
 
 @admin.route("/course/<int:cid>/assignments/<int:aid>/moss",

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -280,7 +280,7 @@ def autograde_backup(bid):
     form = forms.CSRFForm()
     if form.validate_on_submit():
         try:
-            token = autograder.create_autograder_token()
+            token = autograder.create_autograder_token(current_user.id)
             autograder.autograde_backup(token, backup.assignment, backup.id)
             flash('Submitted to the autograder', 'success')
         except ValueError as e:

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -280,7 +280,8 @@ def autograde_backup(bid):
     form = forms.CSRFForm()
     if form.validate_on_submit():
         try:
-            autograder.autograde_backup(backup)
+            token = autograder.create_autograder_token()
+            autograder.autograde_backup(token, backup.assignment, backup.id)
             flash('Submitted to the autograder', 'success')
         except ValueError as e:
             flash(str(e), 'error')

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -679,7 +679,7 @@ def autograde(cid, aid):
         job = jobs.enqueue_job(
             autograder.autograde_assignment,
             description='Autograde {}'.format(assign.display_name),
-            timeout=1800,
+            timeout=2 * 60 * 60,  # 2 hours
             course_id=cid,
             user_id=current_user.id,
             assignment_id=assign.id)

--- a/server/jobs/__init__.py
+++ b/server/jobs/__init__.py
@@ -30,17 +30,17 @@ class JobLogHandler(logging.StreamHandler):
     def contents(self):
         return self.stream.getvalue()
 
-def get_job_id():
+def get_current_job():
     rq_job = rq.get_current_job(connection=get_connection())
-    return rq_job.id
+    return Job.query.get(rq_job.id)
 
 def get_job_logger():
-    return logging.getLogger('{}.job_{}'.format(__name__, get_job_id()))
+    return logging.getLogger('{}.job_{}'.format(__name__, get_current_job().id))
 
 def background_job(f):
     @functools.wraps(f)
     def job_handler(*args, **kwargs):
-        job = Job.query.get(get_job_id())
+        job = get_current_job()
         job.status = 'running'
         db.session.commit()
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -352,19 +352,7 @@ if driver:
             self.driver.find_element_by_class_name('ag-submit-btn').click()
             time.sleep(0.5)
             self.driver.find_element_by_class_name('confirm').click()
-            self.assertTrue("Submitted to the autograder" in self.driver.page_source)
-
-        def test_assignment_send_to_ag_with_no_token(self):
-            self._login(role="admin")
-            self.assignment.autograding_key = ""
-            models.db.session.commit()
-
-            self.page_load(self.get_server_url() + "/admin/course/1/assignments/1")
-
-            self.assertTrue("Queue on Autograder" in self.driver.page_source)
-            self.driver.find_element_by_class_name('ag-submit-btn').submit()
-            self.assertTrue("Assignment has no autograder key" in self.driver.page_source)
-            self.assertTrue("Submitted to the autograder" not in self.driver.page_source)
+            self.assertIn('Autograde {}'.format(self.assignment.display_name), self.driver.page_source)
 
         def test_assignment_send_backup_to_ag(self):
             self._login(role="admin")


### PR DESCRIPTION
Resolves #1002, #1003.

To guard against autograder mishaps, the ok server job will try to autograde a backup again if it doesn't see a score for that backup. Reliability is an end-to-end problem.

In more detail:

We set up a state machine for each backup to check its progress through
the autograder. If any step takes too long, we'll retry autograding that
backup. Ultimately, a backup is considered done when we confirm that
we've received a new score, or if we have reached the retry limit.

Feel free to do some more testing.