### PR TITLE
Publications page in about

### DIFF
--- a/server/controllers/about.py
+++ b/server/controllers/about.py
@@ -6,7 +6,7 @@ about = Blueprint('about', __name__)
 def privacy():
     return render_template('about/privacy.html')
 
-@about.route('/research/')
+@about.route('/publications/')
 def research():
-    return render_template('about/research.html')
+    return render_template('about/publications.html')
 

--- a/server/controllers/about.py
+++ b/server/controllers/about.py
@@ -6,3 +6,7 @@ about = Blueprint('about', __name__)
 def privacy():
     return render_template('about/privacy.html')
 
+@about.route('/research/')
+def research():
+    return render_template('about/research.html')
+

--- a/server/static/css/landing.css
+++ b/server/static/css/landing.css
@@ -83,3 +83,7 @@ header .landing-btn {
   text-align: left;
   padding-top: 0;
 }
+
+.pill-button {
+  border-color: #337ab7;
+}

--- a/server/static/css/landing.css
+++ b/server/static/css/landing.css
@@ -44,6 +44,9 @@ header .landing-btn {
   .landing {
     padding: 1em 0;
   }
+  .btn-group {
+    padding-bottom: 1em;
+  }
 }
 
 .landing .subtitle {

--- a/server/templates/about/publications.html
+++ b/server/templates/about/publications.html
@@ -39,7 +39,7 @@
         </div>
     </div>
     <div class="col-md-6" >
-        <iframe height="275px" width="100%" src="https://www.youtube.com/embed/polTBnMXGQI" frameborder="0" allowfullscreen></iframe>
+        <iframe height="300px" width="100%" src="https://www.youtube.com/embed/polTBnMXGQI" frameborder="0" allowfullscreen></iframe>
     </div>
 </div>
 <hr>

--- a/server/templates/about/research.html
+++ b/server/templates/about/research.html
@@ -9,73 +9,74 @@
     <p> Instructors often use their course data to research the effectiveness of assignments.
         <br> Here's are some of things instructors have published with the help of OK </p>
 </div>
-
 <div class="landing row feature-block">
     <div class="col-md-6" >
         <img class="img-responsive select-none" src="https://ocf.berkeley.edu/~sumukh/img/fuzz-testing.png">
     </div>
     <div class="col-md-6">
-        <h2>Fuzz Testing Projects In Massive Courses</h2>
+        <h2>Automated Test Generation</h2>
         <p>Fuzz-testing projects discovered errors in 50% of students that instructor created tests missed.</p>
-        <span>Sumukh Sridhara, Brian Hou, Jeffrey Lu, and John DeNero. 2016. Fuzz Testing Projects in Massive Courses. In Proceedings of the Third (2016) ACM Conference on Learning @ Scale (L@S '16). ACM, New York, NY, USA, 361-367. DOI: <a href="http://dx.doi.org/10.1145/2876034.2876050"> http://dx.doi.org/10.1145/2876034.2876050</a> </span>
+        <span>Sumukh Sridhara, Brian Hou, Jeffrey Lu, and John DeNero <br> Fuzz Testing Projects in Massive Courses. In Proceedings of the Third (2016) ACM Conference on Learning @ Scale (L@S '16). </span>
         <br> <br/>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Paper</a>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">ACM Link</a>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Video</a>
+        <div class="btn-group">
+            <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Paper</a>
+            <a class="btn pill pill-button btn-rounded" href="http://dl.acm.org/citation.cfm?id=2876050">ACM Link</a>
+            <a class="btn pill pill-button btn-rounded" href="https://www.youtube.com/watch?v=9f4Dkmt2wxA">Video</a>
+        </div>
     </div>
 </div>
+<hr>
+
 <div class="landing row feature-block">
     <div class="col-md-6 center">
         <h2>Course Delivery as a Software Problem</h2>
-        <p>This talk describes how the OK software suite has helped <a href="http://cs61a.org">CS 61A </a> scale to 1600 students in one lecture section..</p>
+        <p>Talk: How the OK Software Suite has helped <a href="http://cs61a.org">CS 61A</a> scale to 1600 students in a single semester.</p>
         <span>John DeNero, EECS Colloqium Invited Talk - October 19, 2016 </span>
         <br> <br>
-        <a class="btn pill pill-button btn-rounded" href="https://www.youtube.com/watch?v=polTBnMXGQI">Video</a>
-        <a class="btn pill pill-button btn-rounded" href="http://lecture.cs61a.org/static/talk.pdf">Slides</a>
+        <div class="btn-group">
+            <a class="btn pill pill-button btn-rounded" href="https://www.youtube.com/watch?v=polTBnMXGQI">Video</a>
+            <a class="btn pill pill-button btn-rounded" href="http://lecture.cs61a.org/static/talk.pdf">Slides</a>
+        </div>
     </div>
     <div class="col-md-6" >
-        <img class="img-responsive select-none" src="{{ url_for('static', filename='img/landing-comments.png') }}">
+        <iframe height="275px" width="100%" src="https://www.youtube.com/embed/polTBnMXGQI" frameborder="0" allowfullscreen></iframe>
     </div>
 </div>
+<hr>
+
 <div class="landing row feature-block">
     <div class="col-md-6" >
-        <img class="img-responsive select-none" src="{{ url_for('static', filename='img/landing-comments.png') }}">
+        <img class="img-responsive select-none" src="https://img.youtube.com/vi/rY4vrEdQKVg/maxresdefault.jpg">
     </div>
 
     <div class="col-md-6">
-        <h2>Kristin Unlocking</h2>
-        <p>This talk describes how the OK software suite has helped <a href="http://cs61a.org">CS 61A </a> scale to 1600 students in one lecture section..</p>
-        <span>Sumukh Sridhara, Brian Hou, Jeffrey Lu, and John DeNero. 2016. Fuzz Testing Projects in Massive Courses. In Proceedings of the Third (2016) ACM Conference on Learning @ Scale (L@S '16). ACM, New York, NY, USA, 361-367. DOI: <a href="http://dx.doi.org/10.1145/2876034.2876050"> http://dx.doi.org/10.1145/2876034.2876050</a> </span>
+        <h2>Identifying Misunderstandings</h2>
+        <p>A technique to identify conceptual misunderstandings from constructed response questions.</p>
+        <span>Kristin Stephens-Marintez, An Ju, Colin Schoen, John DeNero, Armando Fox  <br>  Identifying Student Misunderstandings using Constructed Responses. Extended Abstract at Learning At Scale 2016. ACM L@S ’16 </span>
         <br> <br>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Paper</a>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">ACM Link</a>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Video</a>
+        <div class="btn-group">
+            <a class="btn pill pill-button btn-rounded" href="https://people.eecs.berkeley.edu/~ksteph/papers/l_s_2016_misunderstandings.pdf">Paper</a>
+            <a class="btn pill pill-button btn-rounded" href="http://dx.doi.org/10.1145/2876034.2893395">ACM Link</a>
+            <a class="btn pill pill-button btn-rounded" href="https://people.eecs.berkeley.edu/~ksteph/l_s_2016_misunderstandings.html">Website</a>
+        </div>
     </div>
 </div>
+<hr>
+
 <div class="landing row feature-block">
 
     <div class="col-md-6">
-        <h2>Gustavo Hints</h2>
-        <p>This talk describes how the OK software suite has helped <a href="http://cs61a.org">CS 61A </a> scale to 1600 students in one lecture section..</p>
-        <span>Sumukh Sridhara, Brian Hou, Jeffrey Lu, and John DeNero. 2016. Fuzz Testing Projects in Massive Courses. In Proceedings of the Third (2016) ACM Conference on Learning @ Scale (L@S '16). ACM, New York, NY, USA, 361-367. DOI: <a href="http://dx.doi.org/10.1145/2876034.2876050"> http://dx.doi.org/10.1145/2876034.2876050</a> </span>
+        <h2>Hints from Similiar Submissions </h2>
+        <p>Using program synthesis to create hints using past submissions from others. </p>
+        <span>Rolim, R. et al. (2016) <br> Learning Syntactic Program Transformations from Examples.</span>
         <br> <br>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Paper</a>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">ACM Link</a>
-        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Video</a>
+        <div class="btn-group">
+            <a class="btn pill pill-button btn-rounded" href="https://arxiv.org/pdf/1608.09000">Paper</a>
+            <a class="btn pill pill-button btn-rounded" href="https://arxiv.org/abs/1608.09000">arXiv Link</a>
+        </div>
     </div>
     <div class="col-md-6" >
-        <img class="img-responsive select-none" src="{{ url_for('static', filename='img/landing-comments.png') }}">
-    </div>
-
-</div>
-
-<div class="landing row">
-    <hr>
-
-    <div class="col-md-12">
-        <h2>Learn more about how OK can streamline your course.</h2>
-        <p> OK is an suite of open source software tools to developed to support computer science courses. <br> Contact us to see how OK can help streamline assignment submissions.  </p>
-        <a href="mailto://cs61a@berkeley.edu?cc=denero@berkeley.edu&bcc=sumukh@berkeley.edu&subject=Using%20OK" class="button">Contact us</a>
+        <img class="img-responsive select-none" src="http://i.imgur.com/EIdqu6k.png">
     </div>
 </div>
 

--- a/server/templates/about/research.html
+++ b/server/templates/about/research.html
@@ -1,0 +1,82 @@
+{% extends "about/base.html" %}
+
+{% block title %}OK Publications{% endblock %}
+
+{% block content %}
+
+<div class="landing row feature-block logo-section" style="padding-bottom: 1em">
+    <h2>Publications using OK </h2>
+    <p> Instructors often use their course data to research the effectiveness of assignments.
+        <br> Here's are some of things instructors have published with the help of OK </p>
+</div>
+
+<div class="landing row feature-block">
+    <div class="col-md-6" >
+        <img class="img-responsive select-none" src="https://ocf.berkeley.edu/~sumukh/img/fuzz-testing.png">
+    </div>
+    <div class="col-md-6">
+        <h2>Fuzz Testing Projects In Massive Courses</h2>
+        <p>Fuzz-testing projects discovered errors in 50% of students that instructor created tests missed.</p>
+        <span>Sumukh Sridhara, Brian Hou, Jeffrey Lu, and John DeNero. 2016. Fuzz Testing Projects in Massive Courses. In Proceedings of the Third (2016) ACM Conference on Learning @ Scale (L@S '16). ACM, New York, NY, USA, 361-367. DOI: <a href="http://dx.doi.org/10.1145/2876034.2876050"> http://dx.doi.org/10.1145/2876034.2876050</a> </span>
+        <br> <br/>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Paper</a>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">ACM Link</a>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Video</a>
+    </div>
+</div>
+<div class="landing row feature-block">
+    <div class="col-md-6 center">
+        <h2>Course Delivery as a Software Problem</h2>
+        <p>This talk describes how the OK software suite has helped <a href="http://cs61a.org">CS 61A </a> scale to 1600 students in one lecture section..</p>
+        <span>John DeNero, EECS Colloqium Invited Talk - October 19, 2016 </span>
+        <br> <br>
+        <a class="btn pill pill-button btn-rounded" href="https://www.youtube.com/watch?v=polTBnMXGQI">Video</a>
+        <a class="btn pill pill-button btn-rounded" href="http://lecture.cs61a.org/static/talk.pdf">Slides</a>
+    </div>
+    <div class="col-md-6" >
+        <img class="img-responsive select-none" src="{{ url_for('static', filename='img/landing-comments.png') }}">
+    </div>
+</div>
+<div class="landing row feature-block">
+    <div class="col-md-6" >
+        <img class="img-responsive select-none" src="{{ url_for('static', filename='img/landing-comments.png') }}">
+    </div>
+
+    <div class="col-md-6">
+        <h2>Kristin Unlocking</h2>
+        <p>This talk describes how the OK software suite has helped <a href="http://cs61a.org">CS 61A </a> scale to 1600 students in one lecture section..</p>
+        <span>Sumukh Sridhara, Brian Hou, Jeffrey Lu, and John DeNero. 2016. Fuzz Testing Projects in Massive Courses. In Proceedings of the Third (2016) ACM Conference on Learning @ Scale (L@S '16). ACM, New York, NY, USA, 361-367. DOI: <a href="http://dx.doi.org/10.1145/2876034.2876050"> http://dx.doi.org/10.1145/2876034.2876050</a> </span>
+        <br> <br>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Paper</a>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">ACM Link</a>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Video</a>
+    </div>
+</div>
+<div class="landing row feature-block">
+
+    <div class="col-md-6">
+        <h2>Gustavo Hints</h2>
+        <p>This talk describes how the OK software suite has helped <a href="http://cs61a.org">CS 61A </a> scale to 1600 students in one lecture section..</p>
+        <span>Sumukh Sridhara, Brian Hou, Jeffrey Lu, and John DeNero. 2016. Fuzz Testing Projects in Massive Courses. In Proceedings of the Third (2016) ACM Conference on Learning @ Scale (L@S '16). ACM, New York, NY, USA, 361-367. DOI: <a href="http://dx.doi.org/10.1145/2876034.2876050"> http://dx.doi.org/10.1145/2876034.2876050</a> </span>
+        <br> <br>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Paper</a>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">ACM Link</a>
+        <a class="btn pill pill-button btn-rounded" href="http://denero.org/content/pubs/las16_sridhara_fuzz.pdf">Video</a>
+    </div>
+    <div class="col-md-6" >
+        <img class="img-responsive select-none" src="{{ url_for('static', filename='img/landing-comments.png') }}">
+    </div>
+
+</div>
+
+<div class="landing row">
+    <hr>
+
+    <div class="col-md-12">
+        <h2>Learn more about how OK can streamline your course.</h2>
+        <p> OK is an suite of open source software tools to developed to support computer science courses. <br> Contact us to see how OK can help streamline assignment submissions.  </p>
+        <a href="mailto://cs61a@berkeley.edu?cc=denero@berkeley.edu&bcc=sumukh@berkeley.edu&subject=Using%20OK" class="button">Contact us</a>
+    </div>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
I recently wanted a publications page that I could link to. Nothing inside the app links to this page (nor does it need to) 

![image](https://cloud.githubusercontent.com/assets/882381/22779120/4c0d974c-ee6e-11e6-918f-6425d4bf66d6.png)
