### PR TITLE
Display student url on Admin

### DIFF
--- a/server/static/css/code.css
+++ b/server/static/css/code.css
@@ -278,6 +278,10 @@ table.highlight tr:last-child td.comment-container {
   color: #777;
 }
 
+.score-box {
+  max-height: 200px;
+}
+
 .dl-button {
     background-color: #eee;
     color: #6c6c6c;

--- a/server/static/css/student.css
+++ b/server/static/css/student.css
@@ -497,10 +497,6 @@ header .logo {
   display: none;
 }
 
-.score-box {
-  max-height: 200px;
-}
-
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
   .subcontent {

--- a/server/templates/staff/grading/code.html
+++ b/server/templates/staff/grading/code.html
@@ -90,7 +90,7 @@
                           <span class="label label-default">Unpublished</span>
                         {% endif %}
                       </p>
-                      <pre>{{ score.message }}</pre>
+                      <pre class="score-box">{{ score.message }}</pre>
                       <p>{{ utils.local_time(score.created, backup.assignment.course) }} from {{ score.grader.email }}</p>
                     </li>
                   {% else %}

--- a/server/templates/staff/grading/code.html
+++ b/server/templates/staff/grading/code.html
@@ -80,6 +80,12 @@
                       {{ utils.local_time(backup.custom_submission_time, backup.assignment.course) }}
                     </li>
                   {% endif %}
+                    <li class="list-group-item">
+                      <b>Student URL: </b>
+                      {% with student_url = url_for('student.code', name=backup.assignment.name, bid=backup.id, submit=backup.submit, _external=True) %}
+                      <a href="{{ student_url }}"> {{ student_url }} </a>
+                      {% endwith %}
+                    </li>
                   {% for score in backup.active_scores %}
                     <li class="list-group-item">
                       <p>


### PR DESCRIPTION
Resolves #992 

Also limits the size of score outputs to 200px so the score submission box does not take up lots of space (the rest overflows via scrolling) 

Looks something like this: 
![image](https://cloud.githubusercontent.com/assets/882381/23007027/5089cf74-f3ba-11e6-92ce-d74173630416.png)
(context: this is not actual student contact info - it's from our randomly generated seed data) 

