### PR TITLE
Allow jobs to choose when to save log output

### DIFF
--- a/server/autograder.py
+++ b/server/autograder.py
@@ -178,6 +178,9 @@ def autograde_assignment(assignment_id):
     ]
     num_tasks = len(tasks)
 
+    if not num_tasks:
+        return "No submissions to grade"
+
     def retry_task(task):
         if task.retries >= MAX_RETRIES:
             logger.error('Did not receive a score for backup {} after {} retries'.format(

--- a/server/autograder.py
+++ b/server/autograder.py
@@ -198,8 +198,8 @@ def autograde_assignment(assignment_id):
         graded = len([task for task in tasks
             if task.status in (GradingStatus.DONE, GradingStatus.FAILED)])
 
-        logger.log(jobs.URGENT_LEVEL, 'Graded {:>4}/{} ({:>5.1f}%)'.format(
-                    graded, num_tasks, 100 * graded / num_tasks))
+        logger.critical('Graded {:>4}/{} ({:>5.1f}%)'.format(
+                        graded, num_tasks, 100 * graded / num_tasks))
 
         if graded == num_tasks:
             break

--- a/server/autograder.py
+++ b/server/autograder.py
@@ -197,8 +197,10 @@ def autograde_assignment(assignment_id):
 
         graded = len([task for task in tasks
             if task.status in (GradingStatus.DONE, GradingStatus.FAILED)])
-        logger.info('Graded {:>4}/{} ({:>5.1f}%)'.format(
-            graded, num_tasks, 100 * graded / num_tasks))
+
+        logger.log(jobs.URGENT_LEVEL, 'Graded {:>4}/{} ({:>5.1f}%)'.format(
+                    graded, num_tasks, 100 * graded / num_tasks))
+
         if graded == num_tasks:
             break
 

--- a/server/jobs/__init__.py
+++ b/server/jobs/__init__.py
@@ -9,6 +9,8 @@ import rq
 
 from server.models import db, Job
 
+URGENT_LEVEL = 50
+
 class JobLogHandler(logging.StreamHandler):
     """Stream log contents to buffer and to DB. """
     def __init__(self, stream, job, log_every=10):
@@ -18,11 +20,11 @@ class JobLogHandler(logging.StreamHandler):
         self.counter = 0
         self.log_every = log_every
 
-    def handle(self, record):
+    def handle(self, record, force=True):
         self.counter += 1
         super().handle(record)
         print(record.message)
-        if (self.counter % self.log_every) == 0:
+        if record.levelno >= URGENT_LEVEL or not (self.counter % self.log_every):
             self.job.log = self.contents
             db.session.commit()
 

--- a/server/jobs/__init__.py
+++ b/server/jobs/__init__.py
@@ -9,8 +9,6 @@ import rq
 
 from server.models import db, Job
 
-URGENT_LEVEL = 50
-
 class JobLogHandler(logging.StreamHandler):
     """Stream log contents to buffer and to DB. """
     def __init__(self, stream, job, log_every=10):
@@ -24,7 +22,7 @@ class JobLogHandler(logging.StreamHandler):
         self.counter += 1
         super().handle(record)
         print(record.message)
-        if record.levelno >= URGENT_LEVEL or not (self.counter % self.log_every):
+        if record.levelno >= logging.CRITICAL or not (self.counter % self.log_every):
             self.job.log = self.contents
             db.session.commit()
 

--- a/server/jobs/__init__.py
+++ b/server/jobs/__init__.py
@@ -18,7 +18,7 @@ class JobLogHandler(logging.StreamHandler):
         self.counter = 0
         self.log_every = log_every
 
-    def handle(self, record, force=True):
+    def handle(self, record):
         self.counter += 1
         super().handle(record)
         print(record.message)

--- a/server/jobs/example.py
+++ b/server/jobs/example.py
@@ -13,8 +13,7 @@ def test_job(duration=0, should_fail=False, make_file=False):
     logger = jobs.get_job_logger()
 
     logger.info('Starting...')
-    logger.log(jobs.URGENT_LEVEL,
-               'This job will sleep for {} seconds'.format(duration))
+    logger.critical('This job will sleep for {} seconds'.format(duration))
 
     time.sleep(duration)
     if should_fail:

--- a/server/jobs/example.py
+++ b/server/jobs/example.py
@@ -13,6 +13,9 @@ def test_job(duration=0, should_fail=False, make_file=False):
     logger = jobs.get_job_logger()
 
     logger.info('Starting...')
+    logger.log(jobs.URGENT_LEVEL,
+               'This job will sleep for {} seconds'.format(duration))
+
     time.sleep(duration)
     if should_fail:
         1/0

--- a/server/jobs/moss.py
+++ b/server/jobs/moss.py
@@ -124,7 +124,7 @@ def submit_to_moss(moss_id=None, file_regex=".*", assignment_id=None, language=N
                    .format(lang=language, templates=templates,
                            folder=' '.join(all_student_files)))
 
-        logger.log(jobs.URGENT_LEVEL, "Running {}".format(command[:100] + ' ...'))
+        logger.critical("Running {}".format(command[:100] + ' ...'))
 
         try:
             process = subprocess.check_output(shlex.split(command),

--- a/server/jobs/moss.py
+++ b/server/jobs/moss.py
@@ -44,7 +44,7 @@ def submit_to_moss(moss_id=None, file_regex=".*", assignment_id=None, language=N
                           .order_by(Backup.created.desc())
                           .all())
 
-    logger.info("Retreived {} final submissions".format(len(subm_keys)))
+    logger.info("Retrieved {} final submissions".format(len(subm_keys)))
     # TODO: Customize the location of the tmp writing (especially useful during dev)
 
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/server/jobs/moss.py
+++ b/server/jobs/moss.py
@@ -124,7 +124,7 @@ def submit_to_moss(moss_id=None, file_regex=".*", assignment_id=None, language=N
                    .format(lang=language, templates=templates,
                            folder=' '.join(all_student_files)))
 
-        logger.info("Running {}".format(command[:100] + ' ...'))
+        logger.log(jobs.URGENT_LEVEL, "Running {}".format(command[:100] + ' ...'))
 
         try:
             process = subprocess.check_output(shlex.split(command),


### PR DESCRIPTION
If a message is logged with a level of critical (or higher) - the log is immediately saved (instead of having to wait for 10 more messages) 

This allows jobs some level of control over what gets displayed when. It's especially useful for jobs that might not print lots of information (like the autograding job - previously the user had to wait for about a minute before they got any output) 

