### PR TITLE
Render queue kind on create queues page

### DIFF
--- a/server/templates/staff/grading/assign_tasks.html
+++ b/server/templates/staff/grading/assign_tasks.html
@@ -39,6 +39,7 @@
               {% call forms.render_form(form, action_url="", action_text='Assign Grading Tasks',
                                           class_='form') %}
                   {{ forms.render_field(form.staff, label_visible=true, class_="checkbox-list") }}
+                  {{ forms.render_field(form.kind, label_visible=true) }}
               {% endcall %}
           </div>
           <!-- /.box-body -->


### PR DESCRIPTION
Not sure why this was removed. 

An instructor of a course asked for the ability to grade queues - but not be forced to use the 0-2 scale that composition scoring requires. 