### PR TITLE
Display assignment name (e.g. cal/cs61a/sp17/hw01) as "endpoint"

### DIFF
--- a/server/forms.py
+++ b/server/forms.py
@@ -136,7 +136,7 @@ class AssignmentForm(BaseForm):
 
     display_name = StringField('Display Name',
                                validators=[validators.required()])
-    name = StringField('Offering (example: cal/cs61a/fa16/proj01)',
+    name = StringField('Endpoint (example: cal/cs61a/fa16/proj01)',
                        validators=[validators.required()])
     due_date = DateTimeField('Due Date (Course Time)',
                              validators=[validators.required()])
@@ -180,13 +180,13 @@ class AssignmentForm(BaseForm):
 
         if not has_course_endpoint or not is_valid_endpoint:
             self.name.errors.append(
-                'The name should be of the form {0}/<name>'.format(self.course.offering))
+                'The endpoint should be of the form {0}/<name>'.format(self.course.offering))
             return False
 
         # If the name is changed, ensure assignment offering is unique
         assgn = Assignment.query.filter_by(name=self.name.data).first()
         if assgn:
-            self.name.errors.append('That offering already exists')
+            self.name.errors.append('That endpoint already exists')
             return False
         return True
 

--- a/server/templates/staff/course/assignment/assignment.new.html
+++ b/server/templates/staff/course/assignment/assignment.new.html
@@ -34,7 +34,7 @@
                   {{ forms.render_field(form.display_name, label_visible=true, placeholder='Hog',
                                         required="required", type='text', id="display-name") }}
                   {{ forms.render_field(form.name, label_visible=true, value=current_course.offering + '/',
-                                        placeholder='cal/cs61a/fa16/hog', type='text', id="assignment-offering") }}
+                                        placeholder='cal/cs61a/fa16/hog', type='text', id="assignment-name") }}
                   {{ forms.render_field(form.max_group_size, label_visible=true, type='number', min='1', value='1') }}
                 </fieldset>
                 <h3>Deadlines</h3>
@@ -86,10 +86,10 @@ function registerDisplayName(courseOffering) {
     $('#display-name').on('change, keyup', debounce(function () {
         if (!nameTweaked) {
             displayName = $('#display-name').val().toLowerCase().split(' ').join('')
-            $('#assignment-offering').val(courseOffering + '/' + displayName)
+            $('#assignment-name').val(courseOffering + '/' + displayName)
         }
     }, 25))
-    $('#assignment-offering').keyup(function () {
+    $('#assignment-name').keyup(function () {
         nameTweaked = true;
     })
 }

--- a/server/templates/staff/course/assignment/assignments.html
+++ b/server/templates/staff/course/assignment/assignments.html
@@ -33,7 +33,7 @@
             <table class="table table-striped">
                 <tbody><tr>
                   <th>Name</th>
-                  <th>Offering</th>
+                  <th>Endpoint</th>
                   <th>Visible</th>
                   <th>Due Date</th>
                   <th>Lock Date</th>
@@ -76,7 +76,7 @@
             <table class="table table-striped">
                 <tbody><tr>
                   <th>Name</th>
-                  <th>Offering</th>
+                  <th>Endpoint</th>
                   <th>Visible</th>
                   <th>Due Date</th>
                   <th>Lock Date</th>


### PR DESCRIPTION
Previously this would be displayed as the "offering", but "endpoint" is more consistent with the ok-client terminology.