### PR TITLE
Fix extension permissions check

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -1835,4 +1835,4 @@ class Extension(Model):
             return False
         if user.is_admin:
             return True
-        return user.is_enrolled(obj.course, STAFF_ROLES)
+        return user.is_enrolled(obj.assignment.course, STAFF_ROLES)

--- a/server/models.py
+++ b/server/models.py
@@ -1835,4 +1835,4 @@ class Extension(Model):
             return False
         if user.is_admin:
             return True
-        return user.is_enrolled(obj.assignment.course, STAFF_ROLES)
+        return user.is_enrolled(obj.course.id, STAFF_ROLES)

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -60,6 +60,11 @@ class TestExtension(OkTestCase):
         self.assertEquals(ext, Extension.get_extension(self.user1, self.assignment))
         self.assertFalse(Extension.get_extension(self.user2, self.assignment))
 
+    def test_extension_permissions(self):
+        ext = self._make_ext(self.assignment, self.user1)
+        self.assertFalse(Extension.can(ext, self.user1, 'delete'))
+        self.assertTrue(Extension.can(ext, self.staff1, 'delete'))
+
     def test_extension_expiry(self):
         ext = self._make_ext(self.assignment, self.user1)
         self.assertEquals(ext, Extension.get_extension(self.user1, self.assignment))


### PR DESCRIPTION
`user.is_enrolled` requires a course ID and not an actual course. 

Some sort of type checker might have helped here. 

Relatively low impact for a permissions bugs - a TA reported being unable to delete an extension. 

