### PR TITLE
Send group emails correctly

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -137,11 +137,18 @@ def random_row(query):
         return None
     return query.offset(random.randrange(count)).first()
 
-
-def group_action_email(members, subject, text):
-    emails = [m.user.email for m in members]
-    return send_email(emails, subject, text)
-
+def new_course_email(instructor, course):
+    subject = "{} + OK - Welcome!".format(course.display_name)
+    template = 'email/new_course.html'
+    text = "" # The template already includes the copy
+    link_text = "View OK Documentation"
+    link = url_for('about.documentation', _external=True)
+    return send_email(instructor.email, subject, text,
+               reply_to="sumukh+ok@berkeley.edu",
+               from_name="OK Team",
+               cc=('sumukh+ok@berkeley.edu',), # In prod: 'denero+ok@berkeley.edu'),
+               template=template, link_text=link_text, link=link,
+               course=course, instructor=instructor)
 
 def invite_email(member, recipient, assignment):
     subject = "{0} group invitation".format(assignment.display_name)
@@ -153,6 +160,9 @@ def invite_email(member, recipient, assignment):
     send_email(recipient.email, subject, text, template,
                link_text=link_text, link=link)
 
+def send_emails(recipients, subject, body, **kwargs):
+    for email in recipients:
+        send_email(email, subject, body, **kwargs)
 
 def send_email(to, subject, body, cc=(), from_name='Ok',
                link=None, link_text="Sign in",

--- a/server/utils.py
+++ b/server/utils.py
@@ -137,19 +137,6 @@ def random_row(query):
         return None
     return query.offset(random.randrange(count)).first()
 
-def new_course_email(instructor, course):
-    subject = "{} + OK - Welcome!".format(course.display_name)
-    template = 'email/new_course.html'
-    text = "" # The template already includes the copy
-    link_text = "View OK Documentation"
-    link = url_for('about.documentation', _external=True)
-    return send_email(instructor.email, subject, text,
-               reply_to="sumukh+ok@berkeley.edu",
-               from_name="OK Team",
-               cc=('sumukh+ok@berkeley.edu',), # In prod: 'denero+ok@berkeley.edu'),
-               template=template, link_text=link_text, link=link,
-               course=course, instructor=instructor)
-
 def invite_email(member, recipient, assignment):
     subject = "{0} group invitation".format(assignment.display_name)
     text = "{0} has invited you to join their group".format(member.email)


### PR DESCRIPTION
These were previously 400'ing because we were passing a list when sendgrid expected a single string (which changed because we upgraded the sendgrid library version a while back) 

The "right" way to do this is to use sendgrid personalizations - but that's an issue we can shelve for later #1084 





