### PR TITLE
Send CSRF token in DELETE requests

### DIFF
--- a/server/static/js/comments.js
+++ b/server/static/js/comments.js
@@ -5,7 +5,7 @@ jQuery(document).ready(function($){
      * '<controller>/base.html' template.
      */
     $(document).ajaxSend(function(e, xhr, s) {
-        if (s.type == 'POST' || s.type == 'PUT') {
+        if (s.type == 'POST' || s.type == 'PUT' || s.type == 'DELETE') {
             xhr.setRequestHeader('X-CSRF-Token', csrf_token);
         }
     });


### PR DESCRIPTION
Fixes #1126. The Flask-WTF 0.14 changelog says

> CsrfProtect protects the DELETE method by default