### PR TITLE
Skip students with no email in bCourses import

### DIFF
--- a/server/canvas/jobs.py
+++ b/server/canvas/jobs.py
@@ -74,6 +74,8 @@ def enroll_students(canvas_course_id):
     enrollment_info = []
     logger.info(row_format.format(email='EMAIL', name='NAME', sid='SID'))
     for student in api.get_students(canvas_course):
+        if not student['email']:
+            continue
         info = {
             'email': student['email'],
             'name': student['name'],


### PR DESCRIPTION
One student inexplicably has an `"email": null` in the JSON, causing the job to crash