### PR TITLE
Effort Grading Should Use Extension Dates When Possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ clean:
 lint:
 	flake8 --exclude=env,tests .
 
+tests: test
 test:
 	py.test --cov-report term-missing --cov=server tests/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pymysql==0.7.11
 sqlalchemy==1.1.9
 
 # Caching
+werkzeug
 redis==2.10.5
 
 # Job Queue
@@ -35,7 +36,6 @@ lockfile==0.12.2 # For local storage
 apache-libcloud==1.5.0
 
 # OAuth
-
 oauthlib==2.0.2
 # Flask-OAuthlib==0.9.3
 # OAuthlib version that logs errors - use until Flask-OAuthlib > 0.9.3 is published

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1404,12 +1404,9 @@ def create_extension(cid):
         else:
             expires = utils.server_time_obj(form.expires.data, current_course)
             custom_time = form.get_submission_time(assign)
-
-            ext = Extension(staff=current_user, assignment=assign, user=student,
+            ext = Extension.create(staff=current_user, assignment=assign, user=student,
                             message=form.reason.data, expires=expires,
                             custom_submission_time=custom_time)
-            db.session.add(ext)
-            db.session.commit()
             emails = ', '.join([u.email for u in ext.members()])
             flash("Granted a extension on {} for {} ".format(assign.display_name,
                                                              emails), 'success')
@@ -1427,8 +1424,7 @@ def delete_extension(cid, ext_id):
         abort(401)
 
     if forms.CSRFForm().validate_on_submit():
-        db.session.delete(extension)
-        db.session.commit()
+        Extension.delete(extension)
         flash("Revoked extension", "success")
         return redirect(url_for('.list_extensions', cid=cid))
     abort(401)

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -360,7 +360,7 @@ class BackupSchema(APISchema):
                              eligible_submit)
         if args['submit'] and past_due:
             assign_obj = models.Assignment.by_name(args['assignment'])
-            extension = models.Extension.get_extension(user, assign_obj)
+            extension = models.Extension.get_extension(user, assign_obj, time=backup.created)
             # Submissions after the deadline with an extension are allowed
             if extension:
                 backup.submit = True  # Need to set if the assignment is inactive

--- a/server/models.py
+++ b/server/models.py
@@ -1865,12 +1865,10 @@ class Extension(Model):
         ext = cls(staff=staff, assignment=assignment, user=user, message=message, expires=expires, custom_submission_time=custom_submission_time)
         db.session.add(ext)
 
-        # Retroactively change the submission times of all past late backups
-        # that were created before the expiration time.
+        # Retroactively change the submission times of all past backups
         for backup in ext.get_backups():
-            if backup.created > assignment.due_date:
-                backup.custom_submission_time = custom_submission_time
-                db.session.add(backup)
+            backup.custom_submission_time = custom_submission_time
+            db.session.add(backup)
 
         db.session.commit()
         return ext

--- a/server/models.py
+++ b/server/models.py
@@ -1854,6 +1854,35 @@ class Extension(Model):
     def course(self):
         return self.assignment.course
 
+    def get_backups(self):
+        """ Returns all backups where this extension applies """
+        return Backup.query.filter(Backup.assignment == self.assignment,
+                Backup.created <= self.expires,
+                Backup.submitter == self.user).all()
+
+    @classmethod
+    def create(cls, staff, assignment, user, expires, custom_submission_time=None, message=None):
+        ext = cls(staff=staff, assignment=assignment, user=user, message=message, expires=expires, custom_submission_time=custom_submission_time)
+        db.session.add(ext)
+
+        # Retroactively change the submission times of all past late backups
+        # that were created before the expiration time.
+        for backup in ext.get_backups():
+            if backup.created > assignment.due_date:
+                backup.custom_submission_time = custom_submission_time
+                db.session.add(backup)
+
+        db.session.commit()
+        return ext
+
+    @classmethod
+    def delete(cls, ext):
+        for backup in ext.get_backups():
+            backup.custom_submission_time = None
+            db.session.add(backup)
+        db.session.delete(ext)
+        db.session.commit()
+
     @classmethod
     def get_extension(cls, student, assignment, time=None):
         """ Returns the extension if the student has an extension """

--- a/server/models.py
+++ b/server/models.py
@@ -1855,11 +1855,12 @@ class Extension(Model):
         return self.assignment.course
 
     @classmethod
-    def get_extension(cls, student, assignment):
+    def get_extension(cls, student, assignment, time=None):
         """ Returns the extension if the student has an extension """
+        time = time or dt.datetime.utcnow()
         group_members = assignment.active_user_ids(student.id)
         return cls.query.filter(cls.assignment == assignment,
-                                cls.expires >= dt.datetime.utcnow(),
+                                cls.expires >= time,
                                 cls.user_id.in_(group_members)).first()
 
     @classmethod

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,6 +13,7 @@ class OkTestCase(TestCase):
         return create_app('settings/test.py')
 
     def setUp(self):
+        db.drop_all()
         db.create_all()
 
     def tearDown(self):

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -1,11 +1,12 @@
-from server.models import db, Backup, Group, Message, GradingTask, Score
+from server.models import db, Backup, Extension
 import server.utils as utils
 from server import generate
 from server import constants
 from server.controllers import api
-from server.jobs.effort import effort_score
+from server.jobs.effort import effort_score, get_submission_time
 
 from itertools import zip_longest
+import datetime as dt
 
 from tests import OkTestCase
 
@@ -15,7 +16,7 @@ class TestEffortGrading(OkTestCase):
         super().setUp()
         self.setup_course()
 
-    def make_backup(self, grading=None, attempts=None, submit=False):
+    def make_backup(self, grading=None, attempts=None, submit=False, time=None):
         """
         Create a Backup with specific message info.
 
@@ -36,6 +37,7 @@ class TestEffortGrading(OkTestCase):
         """
         grading = grading or ''
         attempts = attempts or ''
+        custom_time = time or dt.datetime.utcnow()
         messages = {
             'grading': {
                 q: {
@@ -58,7 +60,10 @@ class TestEffortGrading(OkTestCase):
                 }
             }
         }
-        return api.make_backup(self.user1, self.assignment.id, messages, submit)
+        backup = api.make_backup(self.user1, self.assignment.id, messages, submit)
+        backup.created = custom_time
+        db.session.commit()
+        return backup
 
     def score_equals(self, backup, score, qs=2):
         try:
@@ -107,4 +112,29 @@ class TestEffortGrading(OkTestCase):
     def test_effort_missing(self):
         self.score_equals(self.make_backup(grading='f c', attempts='33'), 2, qs=3) # 2
         self.score_equals(self.make_backup(grading='p', attempts=' 3'), 2)
+
+
+    def _make_ext(self, assignment, user, time=None):
+        custom_time = time or dt.datetime.utcnow()
+        ext = Extension(assignment=assignment, user=user,
+                custom_submission_time=custom_time,
+                expires=dt.datetime.utcnow() + dt.timedelta(days=1),
+                staff=self.staff1)
+        db.session.add(ext)
+        db.session.commit()
+        return ext
+
+    def test_extension_submission_time(self):
+        curr_time = dt.datetime.utcnow()
+        self.assignment.due_date = curr_time - dt.timedelta(days=1)
+        backup = self.make_backup(time=curr_time)
+
+        # Submission time shouldn't initially be on time
+        self.assertFalse(backup.submission_time <= self.assignment.due_date)
+
+        ext = self._make_ext(self.assignment, self.user1, time=self.assignment.due_date)
+        custom_submission_time = get_submission_time(backup, self.assignment)
+
+        # Should use the extension's time instead of the backup's time
+        self.assertTrue(custom_submission_time <= self.assignment.due_date)
 


### PR DESCRIPTION
Fixes the following bugs:
- Turns out the `custom_created_time` isn't set on the Backup itself; you have to lookup the time on the corresponding Extension (if it exists).
- Scores for a backup should be added for each member in the group.