### PR TITLE
Fix extensions bug

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1432,6 +1432,10 @@ def create_extension(cid):
         if Extension.get_extension(student, assign):
             flash("{} already has an extension".format(form.email.data), 'danger')
         else:
+            group_members = assign.active_user_ids(student.id)
+            ext = Extension.query.filter(Extension.assignment == assign, Extension.user_id.in_(group_members)).first()
+            if ext:
+                Extension.delete(ext)
             expires = utils.server_time_obj(form.expires.data, current_course)
             custom_time = form.get_submission_time(assign)
             ext = Extension.create(staff=current_user, assignment=assign, user=student,

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -364,10 +364,12 @@ class BackupSchema(APISchema):
             # Submissions after the deadline with an extension are allowed
             if extension:
                 backup.submit = True  # Need to set if the assignment is inactive
-                backup.custom_submission_time = extension.custom_submission_time
+                backup.custom_submission_time = extension.custom_submission_time or assign_obj.due_date
                 eligible_submit = True
             elif lock_flag:
                 raise ValueError('Late Submission of {}'.format(args['assignment']))
+
+        models.db.session.commit()
 
         if (eligible_submit and assignment['autograding_key']
                 and assignment['continuous_autograding']):

--- a/server/generate.py
+++ b/server/generate.py
@@ -219,8 +219,8 @@ def gen_backup(user, assignment):
         messages['file_contents']['submit'] = ''
     backup = Backup.create(
         created=assignment.due_date + datetime.timedelta(seconds=seconds_offset),
-        submitter_id=user.id,
-        assignment_id=assignment.id,
+        submitter=user,
+        assignment=assignment,
         submit=submit)
     backup.messages = [Message(kind=k, contents=m) for k, m in messages.items()]
     return backup

--- a/server/models.py
+++ b/server/models.py
@@ -1700,20 +1700,20 @@ class MossResult(Model):
 
     # Time that Moss was run
     run_time = db.Column(db.DateTime(timezone=True), nullable=False)
-    
+
     # Primary submission and matches of this result (filter by this)
     primary_id = db.Column(db.ForeignKey("backup.id"), nullable=False)
     # Each file key maps to a list of 2 item lists
     # (which represent the start and end of the range, inclusive)
     primary_matches = db.Column(JsonBlob, nullable=False)
-    
+
     # Secondary submission and matches of this result
     secondary_id = db.Column(db.ForeignKey("backup.id"), nullable=False)
     secondary_matches = db.Column(JsonBlob, nullable=False)
-    
+
     # Percentage of primary that is similar to secondary
     similarity = db.Column(db.Integer, nullable=False)
-    
+
     # Tags on this result used for organizing
     tags = db.Column(StringList, nullable=False, default=[])
 
@@ -1923,7 +1923,7 @@ class Extension(Model):
         # Retroactively change the submission times of all past late backups
         # that were created before the expiration time.
         for backup in ext.get_backups():
-            backup.custom_submission_time = custom_submission_time
+            backup.custom_submission_time = custom_submission_time or assignment.due_date
             db.session.add(backup)
 
         db.session.commit()


### PR DESCRIPTION
For some reason, extensions would not get applied to backups when grading, so students were being marked late even though they had an extension.  This PR (and #1176) fixes this for future extensions, but past extensions must be deleted/re-added for them to take into effect (unfortunately).