### PR TITLE
Default grading link to full diff (#1203)

### DIFF
--- a/server/templates/staff/grading/queue.html
+++ b/server/templates/staff/grading/queue.html
@@ -122,7 +122,7 @@
                     {% endif %}
                     <td>
                     {% if item.score_id %}
-                    <a href="{{ url_for(grading_view, bid=item.backup.id, diff='full')}}" class="btn btn-block btn-info btn-flat">
+                    <a href="{{ url_for(grading_view, bid=item.backup.id, diff='full') }}" class="btn btn-block btn-info btn-flat">
                         Regrade
                     </a>
                     {% else %}

--- a/server/templates/staff/grading/queue.html
+++ b/server/templates/staff/grading/queue.html
@@ -122,7 +122,7 @@
                     {% endif %}
                     <td>
                     {% if item.score_id %}
-                    <a href="{{ url_for(grading_view, bid=item.backup.id, diff='full') }}" class="btn btn-block btn-info btn-flat">
+                    <a href="{{ url_for(grading_view, bid=item.backup.id, diff='full')}}" class="btn btn-block btn-info btn-flat">
                         Regrade
                     </a>
                     {% else %}

--- a/server/templates/staff/grading/queue.html
+++ b/server/templates/staff/grading/queue.html
@@ -122,11 +122,11 @@
                     {% endif %}
                     <td>
                     {% if item.score_id %}
-                    <a href="{{ url_for(grading_view, bid=item.backup.id, diff='short') }}" class="btn btn-block btn-info btn-flat">
+                    <a href="{{ url_for(grading_view, bid=item.backup.id, diff='full') }}" class="btn btn-block btn-info btn-flat">
                         Regrade
                     </a>
                     {% else %}
-                    <a href="{{ url_for(grading_view, bid=item.backup.id, diff='short') }}" class="btn btn-block btn-primary btn-flat">
+                    <a href="{{ url_for(grading_view, bid=item.backup.id, diff='full') }}" class="btn btn-block btn-primary btn-flat">
                         Grade
                     </a>
                     {% endif %}


### PR DESCRIPTION
Resolves #1203 - just a template change to make the grading tab show the full diff by default.