### PR TITLE
Turn off autocomplete and spell check for enrollment search

### DIFF
--- a/server/templates/staff/course/enrollment/enrollment.list.html
+++ b/server/templates/staff/course/enrollment/enrollment.list.html
@@ -56,7 +56,7 @@
 
                         <div class="pull-right">
                             <div class="input-group input-group-md" style="width: 200px;">
-                                <input type="text" name="query" class="form-control pull-right search" placeholder="Search">
+                                <input type="text" name="query" class="form-control pull-right search" placeholder="Search" autocomplete="off" autocorrect="off" autocapitalize="off">
                                 <div class="input-group-btn">
                                     <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>
                                 </div>


### PR DESCRIPTION
Autocomplete tends to be incorrect when searching by email and some student names. 

Signed-off-by: Colin Schoen <cschoen@berkeley.edu>