### PR TITLE
Missing current_user import

### DIFF
--- a/server/autograder.py
+++ b/server/autograder.py
@@ -13,6 +13,7 @@ import time
 import oauthlib.common
 import requests
 
+from flask_login import current_user
 from server import constants, jobs, utils
 from server.models import User, Assignment, Backup, Client, Score, Token, db
 


### PR DESCRIPTION
Not entirely sure if this will fix things, but we seem to have dropped this import in the process of cleaning code.