### PR TITLE
Fixes migrations on sqlite by using absolute path

### DIFF
--- a/server/settings/dev.py
+++ b/server/settings/dev.py
@@ -16,9 +16,17 @@ if db_url:
     if 'mysql' in db_url:
         db_url = db_url.replace('mysql://', 'mysql+pymysql://')
         db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+    SQLALCHEMY_DATABASE_URI = db_url
 else:
     SQLALCHEMY_DATABASE_URI = 'sqlite:///../oksqlite.db'
 # SQLALCHEMY_ECHO = True
+
+# If using sqlite use absolute path (otherwise we break migrations)
+sqlite_prefix = 'sqlite:///'
+if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
+    SQLALCHEMY_DATABASE_URI = (sqlite_prefix + 
+            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
+
 
 RQ_DEFAULT_HOST = REDIS_HOST = 'localhost'
 REDIS_PORT = 6379

--- a/server/settings/prod.py
+++ b/server/settings/prod.py
@@ -30,6 +30,13 @@ else:
     sys.exit(1)
 
 SQLALCHEMY_DATABASE_URI = db_url
+
+# If using sqlite use absolute path (otherwise we break migrations)
+sqlite_prefix = 'sqlite:///'
+if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
+    SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
+            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
+
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SENTRY_USER_ATTRS = ['email', 'name']
 PREFERRED_URL_SCHEME = 'https'

--- a/server/settings/simple.py
+++ b/server/settings/simple.py
@@ -26,6 +26,13 @@ else:
     db_url = os.getenv('SQLALCHEMY_URL', 'sqlite:///../oksqlite.db')
 
 SQLALCHEMY_DATABASE_URI = db_url
+
+# If using sqlite use absolute path (otherwise we break migrations)
+sqlite_prefix = 'sqlite:///'
+if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
+    SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
+            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
+
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SENTRY_USER_ATTRS = ['email', 'name']
 PREFERRED_URL_SCHEME = 'https'

--- a/server/settings/staging.py
+++ b/server/settings/staging.py
@@ -36,6 +36,14 @@ else:
     db_url = os.getenv('SQLALCHEMY_URL', 'sqlite:///../oksqlite.db')
 
 SQLALCHEMY_DATABASE_URI = db_url
+
+# If using sqlite use absolute path (otherwise we break migrations)
+sqlite_prefix = 'sqlite:///'
+if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
+    SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
+            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
+
+
 WTF_CSRF_CHECK_DEFAULT = True
 WTF_CSRF_ENABLED = True
 MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # Max Upload Size is 10MB

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -20,6 +20,12 @@ else:
 
 SQLALCHEMY_DATABASE_URI = db_url
 
+# If using sqlite use absolute path (otherwise we break migrations)
+sqlite_prefix = 'sqlite:///'
+if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
+    SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
+            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
+
 WTF_CSRF_CHECK_DEFAULT = False
 WTF_CSRF_ENABLED = False
 


### PR DESCRIPTION
If using `sqlite` and trying to run migrations, an additional `oksqlite.db` file was being added one directory higher than the root repo directory since we are using relative paths in the config. Since `sqlite` is the only file ordinary disk db that is being used this issue won't exist for other databases like `mysql` or `postgres`. Migrations still won't work `sqlite` due to limitations for commands like `ALTER`, but it is plausible that in the future `flask_migrate` will have library support for rewriting those commands into support `sqlite`. 

This PR rewrites paths in `sqlite` db URIs to absolute paths on the fly to ensure we are working on the same `.db` file regardless of the current working directory.

tldr: This fixes an issue most won't notice, but still should probably be merged. 

Signed-off-by: Colin Schoen <cschoen@berkeley.edu>