### PR TITLE
Allows Staff to Create OAuth Clients

### DIFF
--- a/migrations/versions/1266914000cd_oauth_client_status.py
+++ b/migrations/versions/1266914000cd_oauth_client_status.py
@@ -1,0 +1,22 @@
+"""Adds status column to client table
+
+Revision ID: 1266914000cd
+Revises: bb816156989f
+Create Date: 2018-04-08 17:47:45.001678
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1266914000cd'
+down_revision = 'bb816156989f'
+
+from alembic import op
+import sqlalchemy as sa
+import server
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    op.add_column('client', sa.Column('active', sa.Boolean(), default=False))
+
+def downgrade():
+    op.drop_column('client', 'active')

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1321,7 +1321,9 @@ def clients():
     my_clients = [client for client in clients if client.user_id == current_user.id]
     form = forms.ClientForm(client_secret=utils.generate_secret_key())
     if form.validate_on_submit():
-        client = Client(user=current_user)
+        client = Client(
+                user=current_user,
+                active=True if current_user.is_admin else False)
         form.populate_obj(client)
         db.session.add(client)
         db.session.commit()

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -94,7 +94,7 @@ def is_oauth_client_owner(oauth_client_id_arg):
                 oauth_client_id = kwargs[oauth_client_id_arg]
                 clients = Client.query.filter_by(user_id=current_user.id)
                 if clients.count() > 0:
-                    if oauth_client_id in [c.id for c in clients]:
+                    if oauth_client_id in [c.client_id for c in clients]:
                         return func(*args, **kwargs)
             flash("You do not have access to this OAuth client", "warning")
             return redirect(url_for("admin.clients"))
@@ -1352,6 +1352,10 @@ def client(client_id):
 
     client = Client.query.get(client_id)
     form = forms.EditClientForm(obj=client)
+    # Hide the active field and scopes if not an admin
+    if not current_user.is_admin:
+        del form.active
+        del form.default_scopes
     if form.validate_on_submit():
         form.populate_obj(client)
         if form.roll_secret.data:

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1314,7 +1314,7 @@ def enrollment_csv(cid):
     return redirect(url_for(".enrollment", cid=cid))
 
 @admin.route("/clients/", methods=['GET', 'POST'])
-@is_admin()
+@is_staff()
 def clients():
     courses, current_course = get_courses()
     clients = Client.query.all()

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1299,6 +1299,7 @@ def enrollment_csv(cid):
 def clients():
     courses, current_course = get_courses()
     clients = Client.query.all()
+    my_clients = [client for client in clients if client.user_id == current_user.id]
     form = forms.ClientForm(client_secret=utils.generate_secret_key())
     if form.validate_on_submit():
         client = Client(user=current_user)
@@ -1309,7 +1310,11 @@ def clients():
         flash('OAuth client "{}" added'.format(client.name), "success")
         return redirect(url_for(".clients"))
 
-    return render_template('staff/clients.html', clients=clients, form=form, courses=courses)
+    return render_template('staff/clients.html',
+            clients=clients,
+            my_clients=my_clients,
+            form=form,
+            courses=courses)
 
 @admin.route("/clients/<string:client_id>", methods=['GET', 'POST'])
 @is_admin()

--- a/server/controllers/oauth.py
+++ b/server/controllers/oauth.py
@@ -26,11 +26,11 @@ def record_params(setup_state):
 
 @oauth_provider.clientgetter
 def load_client(client_id):
-    return Client.query.filter_by(client_id=client_id).first()
+    return Client.query.filter_by(client_id=client_id, active=True).first()
 
 @oauth_provider.grantgetter
 def load_grant(client_id, code):
-    return Grant.query.filter_by(client_id=client_id, code=code).first()
+    return Grant.query.filter_by(client_id=client_id, active=True, code=code).first()
 
 @oauth_provider.grantsetter
 def save_grant(client_id, code, request, *args, **kwargs):

--- a/server/forms.py
+++ b/server/forms.py
@@ -559,6 +559,11 @@ class ClientForm(BaseForm):
 
 
 class EditClientForm(ClientForm):
+    active = BooleanField(
+            'Active',
+            description='Whether this client is active and available to be used.',
+            default=False
+            )
     roll_secret = BooleanField(
         'Change the secret?',
         description='Should the secret be changed? If checked, the new value will appear after submission',

--- a/server/forms.py
+++ b/server/forms.py
@@ -562,7 +562,7 @@ class EditClientForm(ClientForm):
     active = BooleanField(
             'Active',
             description='Whether this client is active and available to be used.',
-            default=False
+            default=False,
             )
     roll_secret = BooleanField(
         'Change the secret?',

--- a/server/generate.py
+++ b/server/generate.py
@@ -393,7 +393,7 @@ def seed_flags():
 
 def seed_oauth():
     print("Seeding OAuth...")
-    client = Client(
+    client1 = Client(
         name='Example Application',
         client_id='example-app',
         client_secret='example-secret',
@@ -403,10 +403,35 @@ def seed_oauth():
             'http://127.0.0.1:8000/login/authorized',
         ],
         is_confidential=False,
+        active=True,
         description='Sample App for building OAuth',
         default_scopes=OAUTH_SCOPES,
     )
-    db.session.add(client)
+    db.session.add(client1)
+    # Find a non admin staff member
+    client_owner = None
+    for user in User.query.filter_by(is_admin=False):
+        if user.is_staff():
+            client_owner = user
+            break
+    if client_owner:
+        client2 = Client(
+            name='Example Pending OAuth Application',
+            user_id = client_owner.id,
+            user = client_owner,
+            client_id='pending-app',
+            client_secret='example-secret2',
+            redirect_uris=[
+                'http://localhost:8000/authorized',
+                'http://127.0.0.1:8000/authorized',
+                'http://127.0.0.1:8000/login/authorized',
+            ],
+            is_confidential=False,
+            active=False,
+            description='Sample App for building OAuth',
+            default_scopes=[OAUTH_SCOPES[1]], # ['email']
+        )
+        db.session.add(client2)
     db.session.commit()
 
 def seed():

--- a/server/models.py
+++ b/server/models.py
@@ -1601,7 +1601,7 @@ class Client(Model):
     redirect_uris = db.Column(StringList, nullable=False)
     default_scopes = db.Column(StringList, nullable=False)
 
-    status = db.Column(db.Integer, default=0)
+    active = db.Column(db.Boolean, nullable=False, default=False)
 
     @property
     def default_redirect_uri(self):

--- a/server/models.py
+++ b/server/models.py
@@ -1601,6 +1601,8 @@ class Client(Model):
     redirect_uris = db.Column(StringList, nullable=False)
     default_scopes = db.Column(StringList, nullable=False)
 
+    status = db.Column(db.Integer, default=0)
+
     @property
     def default_redirect_uri(self):
         return self.redirect_uris[0]

--- a/server/settings/dev.py
+++ b/server/settings/dev.py
@@ -15,7 +15,8 @@ db_url = os.getenv('DATABASE_URL')
 if db_url:
     if 'mysql' in db_url:
         db_url = db_url.replace('mysql://', 'mysql+pymysql://')
-        db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+#        db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+    SQLALCHEMY_DATABASE_URI = db_url
 else:
     SQLALCHEMY_DATABASE_URI = 'sqlite:///../oksqlite.db'
 # SQLALCHEMY_ECHO = True

--- a/server/settings/dev.py
+++ b/server/settings/dev.py
@@ -14,8 +14,7 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 db_url = os.getenv('DATABASE_URL')
 if db_url:
     if 'mysql' in db_url:
-        db_url = db_url.replace('mysql://', 'mysql+pymysql://')
-#        db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+        db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
     SQLALCHEMY_DATABASE_URI = db_url
 else:
     SQLALCHEMY_DATABASE_URI = 'sqlite:///../oksqlite.db'

--- a/server/settings/dev.py
+++ b/server/settings/dev.py
@@ -20,6 +20,13 @@ else:
     SQLALCHEMY_DATABASE_URI = 'sqlite:///../oksqlite.db'
 # SQLALCHEMY_ECHO = True
 
+# If using sqlite use absolute path (otherwise we break migrations)
+sqlite_prefix = 'sqlite:///'
+if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
+    SQLALCHEMY_DATABASE_URI = (sqlite_prefix + 
+            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
+
+
 RQ_DEFAULT_HOST = REDIS_HOST = 'localhost'
 REDIS_PORT = 6379
 RQ_POLL_INTERVAL = 2000

--- a/server/templates/staff/clients.html
+++ b/server/templates/staff/clients.html
@@ -67,7 +67,6 @@
                     <th>Confidentiality</th>
                     <th>Redirect URIs</th>
                     <th>Default Scopes</th>
-                    <th>Action</th>
                   </tr>
 
                   {% for client in clients %}
@@ -79,12 +78,6 @@
                     <td>{{ 'confidential' if client.is_confidential else 'public'}}</td>
                     <td>{{ client.redirect_uris | join(', ') }}</td>
                     <td>{{ client.default_scopes | join(', ') }}</td>
-                    <td>
-                      {% if client.active %}
-                      <button class="btn btn-primary"><i class="fa fa-trash fa-fw"></i> Remove</button></td>
-                      {% else %}
-                      <button class="btn btn-primary"><i class="fa fa-check fa-fw"></i> Approve</button></td>
-                      {% endif %}
                   </tr>
                   {% endfor %}
                 </tbody>

--- a/server/templates/staff/clients.html
+++ b/server/templates/staff/clients.html
@@ -47,6 +47,7 @@
           </div>
         </div>
       </div>
+      {% if current_user.is_admin %}
       <div class="row">
         <div class="col-md-12">
           <div class="box">
@@ -84,6 +85,7 @@
           </div>
         </div>
       </div>
+      {% endif %}
       <div class="row">
         <div class="col-md-12">
             <div class="box">

--- a/server/templates/staff/clients.html
+++ b/server/templates/staff/clients.html
@@ -25,6 +25,7 @@
                   <tr>
                     <th>Name</th>
                     <th>Owner</th>
+                    <th>Status</th>
                     <th>Client ID</th>
                     <th>Confidentiality</th>
                     <th>Redirect URIs</th>
@@ -35,6 +36,7 @@
                   <tr>
                     <td>{{ client.name }}</td>
                     <td>{{ client.user.name if client.user else 'None' }}</td>
+                    <td><span class="label label-{{ 'primary' if client.active else 'warning' }}">{{ 'Active' if client.active else 'Pending Approval' }}</span></td>
                     <td> <a href="{{ url_for('admin.client',client_id=client.client_id) }}">{{ client.client_id }}</a></td>
                     <td>{{ 'confidential' if client.is_confidential else 'public'}}</td>
                     <td>{{ client.redirect_uris | join(', ') }}</td>

--- a/server/templates/staff/clients.html
+++ b/server/templates/staff/clients.html
@@ -17,7 +17,44 @@
         <div class="col-md-12">
           <div class="box">
             <div class="box-header">
-              <h3 class="box-title">All OAuth Clients</h3>
+              <h3 class="box-title">My OAuth Clients</h3>
+            </div>
+            <div class="box-body table-responsive no-padding">
+              <table class="table table-striped">
+                <tbody>
+                  <tr>
+                    <th>Name</th>
+                    <th>Owner</th>
+                    <th>Client ID</th>
+                    <th>Confidentiality</th>
+                    <th>Redirect URIs</th>
+                    <th>Default Scopes</th>
+                  </tr>
+
+                  {% for client in my_clients %}
+                  <tr>
+                    <td>{{ client.name }}</td>
+                    <td>{{ client.user.name if client.user else 'None' }}</td>
+                    <td> <a href="{{ url_for('admin.client',client_id=client.client_id) }}">{{ client.client_id }}</a></td>
+                    <td>{{ 'confidential' if client.is_confidential else 'public'}}</td>
+                    <td>{{ client.redirect_uris | join(', ') }}</td>
+                    <td>{{ client.default_scopes | join(', ') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="box">
+            <div class="box-header">
+              <h3 class="box-title">
+                <span class="label label-warning">Admin</span> 
+                All OAuth Clients
+              </h3>
             </div>
             <div class="box-body table-responsive no-padding">
               <table class="table table-striped">

--- a/server/templates/staff/clients.html
+++ b/server/templates/staff/clients.html
@@ -35,7 +35,7 @@
                   {% for client in my_clients %}
                   <tr>
                     <td>{{ client.name }}</td>
-                    <td>{{ client.user.name if client.user else 'None' }}</td>
+                    <td>{{ client.user.identifier if client.user else 'None' }}</td>
                     <td><span class="label label-{{ 'primary' if client.active else 'warning' }}">{{ 'Active' if client.active else 'Pending Approval' }}</span></td>
                     <td> <a href="{{ url_for('admin.client',client_id=client.client_id) }}">{{ client.client_id }}</a></td>
                     <td>{{ 'confidential' if client.is_confidential else 'public'}}</td>
@@ -74,7 +74,7 @@
                   {% for client in clients %}
                   <tr>
                     <td>{{ client.name }}</td>
-                    <td>{{ client.user.name if client.user else 'None' }}</td>
+                    <td>{{ client.user.identifier if client.user else 'None' }}</td>
                     <td><span class="label label-{{ 'primary' if client.active else 'warning' }}">{{ 'Active' if client.active else 'Pending Approval' }}</span></td>
                     <td> <a href="{{ url_for('admin.client',client_id=client.client_id) }}">{{ client.client_id }}</a></td>
                     <td>{{ 'confidential' if client.is_confidential else 'public'}}</td>

--- a/server/templates/staff/clients.html
+++ b/server/templates/staff/clients.html
@@ -53,7 +53,6 @@
           <div class="box">
             <div class="box-header">
               <h3 class="box-title">
-                <span class="label label-warning">Admin</span> 
                 All OAuth Clients
               </h3>
             </div>
@@ -63,20 +62,29 @@
                   <tr>
                     <th>Name</th>
                     <th>Owner</th>
+                    <th>Status</th>
                     <th>Client ID</th>
                     <th>Confidentiality</th>
                     <th>Redirect URIs</th>
                     <th>Default Scopes</th>
+                    <th>Action</th>
                   </tr>
 
                   {% for client in clients %}
                   <tr>
                     <td>{{ client.name }}</td>
                     <td>{{ client.user.name if client.user else 'None' }}</td>
+                    <td><span class="label label-{{ 'primary' if client.active else 'warning' }}">{{ 'Active' if client.active else 'Pending Approval' }}</span></td>
                     <td> <a href="{{ url_for('admin.client',client_id=client.client_id) }}">{{ client.client_id }}</a></td>
                     <td>{{ 'confidential' if client.is_confidential else 'public'}}</td>
                     <td>{{ client.redirect_uris | join(', ') }}</td>
                     <td>{{ client.default_scopes | join(', ') }}</td>
+                    <td>
+                      {% if client.active %}
+                      <button class="btn btn-primary"><i class="fa fa-trash fa-fw"></i> Remove</button></td>
+                      {% else %}
+                      <button class="btn btn-primary"><i class="fa fa-check fa-fw"></i> Approve</button></td>
+                      {% endif %}
                   </tr>
                   {% endfor %}
                 </tbody>

--- a/server/templates/staff/clients.html
+++ b/server/templates/staff/clients.html
@@ -7,7 +7,7 @@
 <section class="content-header">
   <h1>OAuth Clients</h1>
   <ol class="breadcrumb">
-    <li><i class="fa fa-dashboard"></i>OAuth Clients</li>
+    <li><i class="fa fa-dashboard"></i> OAuth Clients</li>
   </ol>
 </section>
 
@@ -17,13 +17,14 @@
         <div class="col-md-12">
           <div class="box">
             <div class="box-header">
-              <h3 class="box-title">OAuth Clients</h3>
+              <h3 class="box-title">All OAuth Clients</h3>
             </div>
             <div class="box-body table-responsive no-padding">
               <table class="table table-striped">
                 <tbody>
                   <tr>
                     <th>Name</th>
+                    <th>Owner</th>
                     <th>Client ID</th>
                     <th>Confidentiality</th>
                     <th>Redirect URIs</th>
@@ -33,6 +34,7 @@
                   {% for client in clients %}
                   <tr>
                     <td>{{ client.name }}</td>
+                    <td>{{ client.user.name if client.user else 'None' }}</td>
                     <td> <a href="{{ url_for('admin.client',client_id=client.client_id) }}">{{ client.client_id }}</a></td>
                     <td>{{ 'confidential' if client.is_confidential else 'public'}}</td>
                     <td>{{ client.redirect_uris | join(', ') }}</td>

--- a/server/templates/staff/edit_client.html
+++ b/server/templates/staff/edit_client.html
@@ -29,9 +29,13 @@
                       {{ forms.render_checkbox_field(form.roll_secret, label_visible=true) }}
                       <!-- Client Secret is not rendered -->
                       {{ forms.render_checkbox_field(form.is_confidential, label_visible=true) }}
+                      {% if current_user.is_admin %}
                       {{ forms.render_checkbox_field(form.active, label_visible=true) }}
+                      {% endif %}
                       {{ forms.render_field(form.redirect_uris, placeholder='http://localhost:8000/authorized,https://cs61a.org/oauth/authorized', label_visible=true) }}
+                      {% if current_user.is_admin %}
                       {{ forms.render_field(form.default_scopes, placeholder='email,all', label_visible=true) }}
+                      {% endif %}
 
                     {% endcall %}
                  </div>

--- a/server/templates/staff/edit_client.html
+++ b/server/templates/staff/edit_client.html
@@ -29,6 +29,7 @@
                       {{ forms.render_checkbox_field(form.roll_secret, label_visible=true) }}
                       <!-- Client Secret is not rendered -->
                       {{ forms.render_checkbox_field(form.is_confidential, label_visible=true) }}
+                      {{ forms.render_checkbox_field(form.active, label_visible=true) }}
                       {{ forms.render_field(form.redirect_uris, placeholder='http://localhost:8000/authorized,https://cs61a.org/oauth/authorized', label_visible=true) }}
                       {{ forms.render_field(form.default_scopes, placeholder='email,all', label_visible=true) }}
 

--- a/server/templates/staff/navbar.html
+++ b/server/templates/staff/navbar.html
@@ -10,9 +10,25 @@
 {% endset %}
 
 {% set api_dropdown %}
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown">API <span class="caret"></span></a>
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+            API <span class="caret"></span>
+            {% if current_user.is_admin and num_pending_oauth_clients > 0 %}
+            <span class="label label-warning pull-right">
+              {{ num_pending_oauth_clients }}
+            </span>
+            {% endif %}
+          </a>
           <ul class="dropdown-menu" role="menu">
-            <li><a href="{{ url_for('.clients') }}">OAuth Clients</a></li>
+            <li>
+              <a href="{{ url_for('.clients') }}">
+                OAuth Clients
+                {% if current_user.is_admin and num_pending_oauth_clients > 0 %}
+                <span class="label label-warning pull-right">
+                  {{ num_pending_oauth_clients }}
+                </span>
+                {% endif %}
+              </a>
+            </li>
             {% if current_user.is_admin %}
               <li><a href="{{ url_for('.client_version', name='ok-client') }}">OK Client Version</a></li>
             {% endif %}

--- a/server/templates/staff/navbar.html
+++ b/server/templates/staff/navbar.html
@@ -12,11 +12,11 @@
 {% set api_dropdown %}
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">API <span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
+            <li><a href="{{ url_for('.clients') }}">OAuth Clients</a></li>
             {% if current_user.is_admin %}
-              <li><a href="{{ url_for('.clients') }}">OAuth Clients</a></li>
               <li><a href="{{ url_for('.client_version', name='ok-client') }}">OK Client Version</a></li>
-              <li class="divider"></li>
             {% endif %}
+            <li class="divider"></li>
             <li><a href="{{ url_for('about.documentation' )}}">Documentation</a></li>
             <li class="divider"></li>
             <li><a href="https://ok-oauth.app.cs61a.org">Access Token</a></li>

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -12,6 +12,36 @@ from server.utils import encode_id
 from tests import OkTestCase
 
 class TestOAuth(OkTestCase):
+    def _setup_clients_inactive(self, scope='email'):
+        self.setup_course()
+
+        self.oauth_client = Client(
+            name='Testing Inactive Client', client_id='normal-inactive',
+            client_secret='normal-inactive',
+            redirect_uris=['http://127.0.0.1:8000/authorized'],
+            is_confidential=False,
+            active=False,
+            description='Sample App for testing OAuth',
+            default_scopes=scope
+        )
+        db.session.add(self.oauth_client)
+        db.session.commit()
+
+        self.temp_grant = Grant(
+            user_id=self.user1.id, client_id='normal',
+            code='12345', scopes=['email'],
+            expires=dt.datetime.utcnow() + dt.timedelta(seconds=100)
+        )
+        db.session.add(self.temp_grant)
+
+        self.valid_token = Token(
+            user_id=self.user1.id, client_id='normal',
+            scopes=[scope],
+            access_token='soo_valid', expires=dt.datetime.utcnow() + dt.timedelta(seconds=3600)
+        )
+        db.session.add(self.valid_token)
+        db.session.commit()
+
     def _setup_clients(self, scope='email'):
         self.setup_course()
 
@@ -19,6 +49,7 @@ class TestOAuth(OkTestCase):
             name='Testing Client', client_id='normal', client_secret='normal',
             redirect_uris=['http://127.0.0.1:8000/authorized'],
             is_confidential=False,
+            active=True,
             description='Sample App for testing OAuth',
             default_scopes=scope
         )
@@ -61,10 +92,17 @@ class TestOAuth(OkTestCase):
         db.session.add(self.valid_token_all_scope)
         db.session.commit()
 
-    def test_api(self):
+    def test_api_inactive_client(self):
+        self._setup_clients_inactive()
+        response = self.client.get("/api/v3/user/?access_token={}".format(self.valid_token.access_token))
+        self.assert_200(response)
+        self.assertTrue(b'Error' in response.data)
+
+    def test_api_active_client(self):
         self._setup_clients()
         response = self.client.get("/api/v3/user/?access_token={}".format(self.valid_token.access_token))
         self.assert_200(response)
+        self.assertFalse(b'Error' in response.data)
 
         response = self.client.get("/api/v3/user/?access_token={}".format(self.valid_token_bad_scope.access_token))
         self.assert_403(response)
@@ -204,11 +242,11 @@ class TestOAuth(OkTestCase):
         self.login(self.staff1.email)
         self.assert_200(self.client.get('/admin/clients/'))
 
-        response = self.client.post('/admin/clients/', data={})
-        self.assertRedirects(response, '/admin/')
-
         self.login(self.user1.email)
         response = self.client.get('/admin/clients/')
+        self.assertRedirects(response, '/admin/')
+
+        response = self.client.post('/admin/clients/', data={})
         self.assertRedirects(response, '/admin/')
 
         self.logout()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -71,6 +71,7 @@ if driver:
                 client_secret='secret',
                 redirect_uris=['http://example.com/'],
                 is_confidential=False,
+                active=True
                 description='Sample App for testing OAuth',
                 default_scopes=['email'],
             )


### PR DESCRIPTION
Adds a boolean `active` attribute to the `Client` model indicating if the `Client` is active or requires approval. 
Allows staff (non admins) to view the `/admin/clients` page and create an inactive OAuth client.

Admins are presented with a visual indicator in the nav bar of pending OAuth clients to review. 

<img width="184" alt="screen shot 2018-04-16 at 19 48 11" src="https://user-images.githubusercontent.com/2927722/38846032-1cc6bf28-41af-11e8-8d68-c2836548d880.png">

Admins can still see all OAuth clients except an additional `status` tag is present in the table.

<img width="385" alt="screen shot 2018-04-16 at 19 49 12" src="https://user-images.githubusercontent.com/2927722/38846073-41e3b5e0-41af-11e8-90fa-f1130b9396b4.png">

Admins are able to approve/unapprove clients in the existing edit client page `/admin/clients/{id}`

<img width="441" alt="image" src="https://user-images.githubusercontent.com/2927722/38846096-619de978-41af-11e8-872b-563f8d060b12.png">

Staff members are unable to change the status `Active` or scope `default_scopes` of their clients.

Inactive OAuth clients are not permitted to serve OAuth requests.


