### PR TITLE
Add integration tests for cloud storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ _cache/*
 # local development
 database.db
 *.db
+*.db-journal

--- a/circle.yml
+++ b/circle.yml
@@ -18,5 +18,4 @@ dependencies:
 test:
   override:
     - py.test --junitxml $CIRCLE_TEST_REPORTS/django/results.xml --cov-report term-missing --cov=server tests/ :
-        parallel: true # not a huge advantage since the test suite is short, but evenutally could be useful
         timeout: 1200

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ Flask-Login==0.4.0
 
 # File Storage
 lockfile==0.12.2 # For local storage
-apache-libcloud==1.5.0
+apache-libcloud==2.3.0
 
 # OAuth
 

--- a/server/settings/dev.py
+++ b/server/settings/dev.py
@@ -39,7 +39,7 @@ STORAGE_SERVER = False
 STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',
                                    os.path.abspath("./local-storage"))
 STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
-STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '')
+STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
 
 if STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(STORAGE_CONTAINER):
     os.makedirs(STORAGE_CONTAINER)

--- a/server/settings/prod.py
+++ b/server/settings/prod.py
@@ -59,7 +59,7 @@ STORAGE_PROVIDER = os.environ.get('STORAGE_PROVIDER',  'GOOGLE_STORAGE')
 STORAGE_SERVER = False
 STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',  'ok-v3-user-files')
 STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
-STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '')
+STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
 
 try:
     os.environ["GOOGLE_ID"]

--- a/server/settings/staging.py
+++ b/server/settings/staging.py
@@ -52,7 +52,7 @@ STORAGE_PROVIDER = os.environ.get('STORAGE_PROVIDER',  'LOCAL')
 STORAGE_SERVER = False
 STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',  'ok-v3-user-files')
 STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
-STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '')
+STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
 
 if STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(STORAGE_CONTAINER):
     os.makedirs(STORAGE_CONTAINER)

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -36,6 +36,9 @@ STORAGE_KEY = os.getenv('STORAGE_KEY')
 # TODO(@colinschoen) Ensure that secrets with newlines are correctly parsed
 STORAGE_SECRET = os.getenv('STORAGE_SECRET')
 
+if STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(STORAGE_CONTAINER):
+    os.makedirs(STORAGE_CONTAINER)
+
 CACHE_TYPE = 'simple'
 
 RQ_DEFAULT_HOST = REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -33,9 +33,6 @@ STORAGE_PROVIDER = 'LOCAL'
 STORAGE_SERVER = False
 STORAGE_CONTAINER = os.path.abspath("./local-storage")
 
-if not os.path.exists(STORAGE_CONTAINER):
-    os.makedirs(STORAGE_CONTAINER)
-
 CACHE_TYPE = 'simple'
 
 RQ_DEFAULT_HOST = REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -32,9 +32,8 @@ WTF_CSRF_ENABLED = False
 STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'LOCAL')
 STORAGE_SERVER = False
 STORAGE_CONTAINER = os.getenv('STORAGE_CONTAINER', os.path.abspath('./local-storage'))
-STORAGE_KEY = os.getenv('STORAGE_KEY')
-# TODO(@colinschoen) Ensure that secrets with newlines are correctly parsed
-STORAGE_SECRET = os.getenv('STORAGE_SECRET')
+STORAGE_KEY = os.getenv('STORAGE_KEY', '')
+STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
 
 if STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(STORAGE_CONTAINER):
     os.makedirs(STORAGE_CONTAINER)

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -33,6 +33,7 @@ STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'LOCAL')
 STORAGE_SERVER = False
 STORAGE_CONTAINER = os.getenv('STORAGE_CONTAINER', os.path.abspath('./local-storage'))
 STORAGE_KEY = os.getenv('STORAGE_KEY')
+# TODO(@colinschoen) Ensure that secrets with newlines are correctly parsed
 STORAGE_SECRET = os.getenv('STORAGE_SECRET')
 
 CACHE_TYPE = 'simple'

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -29,9 +29,11 @@ if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
 WTF_CSRF_CHECK_DEFAULT = False
 WTF_CSRF_ENABLED = False
 
-STORAGE_PROVIDER = 'LOCAL'
+STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'LOCAL')
 STORAGE_SERVER = False
-STORAGE_CONTAINER = os.path.abspath("./local-storage")
+STORAGE_CONTAINER = os.getenv('STORAGE_CONTAINER', os.path.abspath('./local-storage'))
+STORAGE_KEY = os.getenv('STORAGE_KEY')
+STORAGE_SECRET = os.getenv('STORAGE_SECRET')
 
 CACHE_TYPE = 'simple'
 

--- a/server/storage.py
+++ b/server/storage.py
@@ -59,13 +59,9 @@ class Storage:
             # Filed Issue: https://issues.apache.org/jira/browse/LIBCLOUD-895
             driver_cls.supports_chunked_encoding = True
 
-        # TODO(@clewolff) Refactor to support passing project_id.
         self.driver = driver_cls(key, secret)
         # Also test credentials by getting the container
-        try:
-            self.container = self.driver.get_container(self.container_name)
-        except ContainerDoesNotExistError:
-            self.container = self.driver.create_container(self.container_name)
+        self.container = self.driver.get_container(self.container_name)
 
     def upload(self, iterable, name=None, container=None, prefix=""):
         """ Upload (and overwrite) files on storage provider.

--- a/server/storage.py
+++ b/server/storage.py
@@ -59,6 +59,7 @@ class Storage:
             # Filed Issue: https://issues.apache.org/jira/browse/LIBCLOUD-895
             driver_cls.supports_chunked_encoding = True
 
+        # TODO(@clewolff) Refactor to support passing project_id.
         self.driver = driver_cls(key, secret)
         # Also test credentials by getting the container
         try:

--- a/server/storage.py
+++ b/server/storage.py
@@ -61,7 +61,7 @@ class Storage:
 
         self.driver = driver_cls(key, secret)
         # Also test credentials by getting the container
-        self.container = self.driver.get_container(self.container_name)
+        self.container = self.driver.get_container(container_name=self.container_name)
 
     def upload(self, iterable, name=None, container=None, prefix=""):
         """ Upload (and overwrite) files on storage provider.

--- a/server/storage.py
+++ b/server/storage.py
@@ -9,7 +9,7 @@ import string
 from urllib.parse import urlencode, urljoin
 
 from werkzeug.utils import secure_filename
-from libcloud.storage.types import Provider
+from libcloud.storage.types import Provider, ContainerDoesNotExistError
 from libcloud.storage.providers import get_driver
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,10 @@ class Storage:
 
         self.driver = driver_cls(key, secret)
         # Also test credentials by getting the container
-        self.container = self.driver.get_container(container_name=self.container_name)
+        try:
+            self.container = self.driver.get_container(self.container_name)
+        except ContainerDoesNotExistError:
+            self.container = self.driver.create_container(self.container_name)
 
     def upload(self, iterable, name=None, container=None, prefix=""):
         """ Upload (and overwrite) files on storage provider.

--- a/server/storage.py
+++ b/server/storage.py
@@ -9,7 +9,7 @@ import string
 from urllib.parse import urlencode, urljoin
 
 from werkzeug.utils import secure_filename
-from libcloud.storage.types import Provider, ContainerDoesNotExistError
+from libcloud.storage.types import Provider
 from libcloud.storage.providers import get_driver
 
 logger = logging.getLogger(__name__)

--- a/server/storage.py
+++ b/server/storage.py
@@ -84,6 +84,8 @@ class Storage:
             obj_name = sanitize_filename(prefixed_name)
         elif prefix:
             obj_name = prefix.lstrip("/") + obj_name
+            obj_name = '/'.join(part if part not in (".", "..") else '_'
+                                for part in obj_name.split("/"))
         logger.info("Beginning upload of {}".format(name))
         obj = self.driver.upload_object_via_stream(iterator=iter(iterable),
                                                    container=container,
@@ -127,7 +129,8 @@ class Storage:
         if container_name is None:
             container_name = self.container_name
         driver_name = self.driver.name.lower()
-        expires = (dt.datetime.now() + dt.timedelta(seconds=timeout)).strftime("%s")
+        expires = (dt.datetime.now() + dt.timedelta(seconds=timeout))
+        expires = int(expires.timestamp())
 
         if 's3' in driver_name or 'google' in driver_name:
             keyIdName = "AWSAccessKeyId" if "s3" in driver_name else "GoogleAccessId"

--- a/server/storage.py
+++ b/server/storage.py
@@ -84,7 +84,7 @@ class Storage:
             obj_name = sanitize_filename(prefixed_name)
         elif prefix:
             obj_name = prefix.lstrip("/") + obj_name
-            obj_name = '/'.join(part if part not in (".", "..") else '_'
+            obj_name = "/".join(part if part not in (".", "..") else "_"
                                 for part in obj_name.split("/"))
         logger.info("Beginning upload of {}".format(name))
         obj = self.driver.upload_object_via_stream(iterator=iter(iterable),

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -3,7 +3,6 @@ import os
 import hashlib
 
 from libcloud.storage.types import ObjectDoesNotExistError
-import pytest
 
 from tests import OkTestCase
 
@@ -106,13 +105,13 @@ class TestFile(OkTestCase):
     test_malicious_directory_traversal_expected_obj_name = "test_.._.._fizz.txt"
 
     def test_malicious_local_get_blob(self):
-        with pytest.raises(ObjectDoesNotExistError):
+        with self.assertRaises(ObjectDoesNotExistError):
             blob = storage.get_blob(obj_name='../README.md')
 
-        with pytest.raises(ObjectDoesNotExistError):
+        with self.assertRaises(ObjectDoesNotExistError):
             blob = storage.get_blob(obj_name='/bin/bash')
 
-        with pytest.raises(ObjectDoesNotExistError):
+        with self.assertRaises(ObjectDoesNotExistError):
             blob = storage.get_blob(obj_name='foobar.txt')
 
     def test_permission(self):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -40,14 +40,8 @@ class TestFile(OkTestCase):
     def tearDown(self):
         super().tearDown()
 
-        try:
-            self.blob1.delete()
-        except ObjectDoesNotExistError:
-            pass
-        try:
-            self.blob2.delete()
-        except ObjectDoesNotExistError:
-            pass
+        delete_silently(self.blob1)
+        delete_silently(self.blob2)
 
     def test_simple(self):
         self.assertEquals(self.blob1.driver.key, storage.driver.key)
@@ -225,3 +219,10 @@ class TestFile(OkTestCase):
     def verify_binary_download(self, file_path, downloaded_data):
         with open(file_path, "rb") as fobj:
             self.assertEqual(fobj.read(), downloaded_data)
+
+
+def delete_silently(blob):
+    try:
+        blob.delete()
+    except (ObjectDoesNotExistError, PermissionError):
+        pass

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -32,7 +32,7 @@ class TestFile(OkTestCase):
                                                course_id=self.course.id,
                                                staff_file=False,
                                                assignment_id=self.assignment.id)
-            self.blob2 = self.file1.object()
+            self.blob2 = self.file2.object()
 
         db.session.add_all([self.file1, self.file2])
         db.session.commit()

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -10,6 +10,8 @@ To run tests for Google Cloud Platform, set the following environment variables:
 - GCP_STORAGE_SECRET
 
 """
+# TODO(@colinschoen) Configure CI to run the full integration test suite only on protected branches like master.
+
 import os
 import random
 import unittest

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -32,14 +32,13 @@ class CloudTestFile(TestFile):
         cls.storage_key = os.environ.get(cls.key_env_name)
         cls.storage_secret = os.environ.get(cls.secret_env_name)
         if not cls.storage_key or not cls.storage_secret:
-            raise unittest.SkipTest("Cloud storage credentials for "
-                                    "%s not configured" % cls.storage_provider)
+            raise unittest.SkipTest("Cloud storage credentials for {} not configured".format(cls.storage_provider))
 
     def create_app(self):
         os.environ["STORAGE_PROVIDER"] = self.storage_provider
         os.environ["STORAGE_KEY"] = self.storage_key
         os.environ["STORAGE_SECRET"] = self.storage_secret
-        os.environ.setdefault("STORAGE_CONTAINER", "okpycloudfilestest%d" % random.randint(0, 100000))
+        os.environ.setdefault("STORAGE_CONTAINER", "okpycloudfilestest{}".format(random.randint(0, 100000)))
 
         return super().create_app()
 

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -8,6 +8,7 @@ CloudTestFile.
 To run tests for Google Cloud Platform, set the following environment variables:
 - GCP_STORAGE_KEY
 - GCP_STORAGE_SECRET
+- GCP_STORAGE_CONTAINER
 
 """
 # TODO(@colinschoen) Configure CI to run the full integration test suite only on protected branches like master.

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -26,9 +26,11 @@ class EnvironmentMutationMixin(object):
     __env_backup = {}
 
     @classmethod
-    def set_environment_variable(cls, key, value):
-        cls.__env_backup.setdefault(key, os.environ.get(key))
-        os.environ[key] = value
+    def set_environment_variable(cls, key, value, keep_existing=False):
+        old_value = os.environ.get(key)
+        cls.__env_backup.setdefault(key, old_value)
+        if not old_value or not keep_existing:
+            os.environ[key] = value
 
     @classmethod
     def restore_environment_variable(cls, key):
@@ -60,7 +62,7 @@ class CloudTestFile(TestFile, EnvironmentMutationMixin):
         cls.set_environment_variable("STORAGE_PROVIDER", cls.storage_provider)
         cls.set_environment_variable("STORAGE_KEY", storage_key)
         cls.set_environment_variable("STORAGE_SECRET", storage_secret)
-        cls.set_environment_variable("STORAGE_CONTAINER", cls._storage_container)
+        cls.set_environment_variable("STORAGE_CONTAINER", cls._storage_container, keep_existing=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -27,7 +27,7 @@ class EnvironmentMutationMixin(object):
 
     @classmethod
     def set_environment_variable(cls, key, value):
-        cls.__env_backup[key] = os.environ.get(key)
+        cls.__env_backup.setdefault(key, os.environ.get(key))
         os.environ[key] = value
 
     @classmethod

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -27,6 +27,8 @@ class CloudTestFile(TestFile):
     key_env_name = ""
     secret_env_name = ""
 
+    _storage_container = "okpycloudfilestest{}".format(random.randint(0, 100000))
+
     __env_backup = {}
 
     @classmethod
@@ -35,7 +37,6 @@ class CloudTestFile(TestFile):
 
         storage_key = os.environ.get(cls.key_env_name)
         storage_secret = os.environ.get(cls.secret_env_name)
-        storage_container = "okpycloudfilestest{}".format(random.randint(0, 100000))
 
         if not storage_key or not storage_secret:
             raise unittest.SkipTest("Cloud storage credentials for {} not configured".format(cls.storage_provider))
@@ -43,7 +44,7 @@ class CloudTestFile(TestFile):
         cls.set_environment_variable("STORAGE_PROVIDER", cls.storage_provider)
         cls.set_environment_variable("STORAGE_KEY", storage_key)
         cls.set_environment_variable("STORAGE_SECRET", storage_secret)
-        cls.set_environment_variable("STORAGE_CONTAINER", storage_container)
+        cls.set_environment_variable("STORAGE_CONTAINER", cls._storage_container)
 
     @classmethod
     def tearDownClass(cls):
@@ -54,10 +55,8 @@ class CloudTestFile(TestFile):
         cls.restore_environment_variable("STORAGE_SECRET")
         cls.restore_environment_variable("STORAGE_CONTAINER")
 
-        for obj in storage.container.list_objects():
-            obj.delete()
-
-        storage.container.delete()
+        container = storage.driver.get_container(cls._storage_container)
+        storage.driver.delete_container(container)
 
     def fetch_file(self, url):
         client_response = self.client.get(url)

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -80,15 +80,15 @@ class CloudTestFile(TestFile, EnvironmentMutationMixin):
     def verify_download_headers(self, headers, filename, content_type):
         pass
 
+    test_prefix_expected_obj_name = 'test/fizz.txt'
+    test_malicious_directory_traversal_expected_obj_name = 'test/_/_/fizz.txt'
+
 
 class GoogleCloudTestFile(CloudTestFile):
     storage_provider = "GOOGLE_STORAGE"
     key_env_name = "GCP_STORAGE_KEY"
     secret_env_name = "GCP_STORAGE_SECRET"
     container_env_name = "GCP_STORAGE_CONTAINER"
-
-    test_prefix_expected_obj_name = 'test/fizz.txt'
-    test_malicious_directory_traversal_expected_obj_name = 'test/_/_/fizz.txt'
 
 
 del CloudTestFile, TestFile

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -1,0 +1,79 @@
+"""
+This module contains integration tests which verify the behavior of the storage
+module against supported cloud storage providers. The tests for the local
+(directory-based) storage backend are re-used and run for each supported cloud
+storage provider. To add tests for a new provider, create a new subclass of
+CloudTestFile.
+
+To run tests for Google Cloud Platform, set the following environment variables:
+- GCP_STORAGE_KEY
+- GCP_STORAGE_SECRET
+
+"""
+import os
+import random
+import unittest
+
+import requests
+
+from server.extensions import storage
+from tests.test_files import TestFile
+
+
+class CloudTestFile(TestFile):
+    storage_provider = ""
+    key_env_name = ""
+    secret_env_name = ""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.storage_key = os.environ.get(cls.key_env_name)
+        cls.storage_secret = os.environ.get(cls.secret_env_name)
+        if not cls.storage_key or not cls.storage_secret:
+            raise unittest.SkipTest("Cloud storage credentials for "
+                                    "%s not configured" % cls.storage_provider)
+
+    def create_app(self):
+        os.environ["STORAGE_PROVIDER"] = self.storage_provider
+        os.environ["STORAGE_KEY"] = self.storage_key
+        os.environ["STORAGE_SECRET"] = self.storage_secret
+        os.environ.setdefault("STORAGE_CONTAINER", "okpycloudfilestest%d" % random.randint(0, 100000))
+
+        return super().create_app()
+
+    def tearDown(self):
+        super().tearDown()
+
+        del os.environ["STORAGE_PROVIDER"]
+        del os.environ["STORAGE_KEY"]
+        del os.environ["STORAGE_SECRET"]
+        del os.environ["STORAGE_CONTAINER"]
+
+        for obj in storage.container.list_objects():
+            obj.delete()
+
+        storage.container.delete()
+
+    def fetch_file(self, url):
+        client_response = self.client.get(url)
+        self.assertStatus(client_response, 302)
+        redirect_response = requests.get(client_response.location)
+        redirect_response.raise_for_status()
+        return redirect_response.headers, redirect_response.content
+
+    def verify_download_headers(self, headers, filename, content_type):
+        pass
+
+
+class GoogleCloudTestFile(CloudTestFile):
+    storage_provider = "GOOGLE_STORAGE"
+    key_env_name = "GCP_STORAGE_KEY"
+    secret_env_name = "GCP_STORAGE_SECRET"
+
+    test_prefix_expected_obj_name = 'test/fizz.txt'
+    test_malicious_directory_traversal_expected_obj_name = 'test/_/_/fizz.txt'
+
+
+del CloudTestFile, TestFile

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -22,14 +22,30 @@ from server.extensions import storage
 from tests.test_files import TestFile
 
 
-class CloudTestFile(TestFile):
+class EnvironmentMutationMixin(object):
+    __env_backup = {}
+
+    @classmethod
+    def set_environment_variable(cls, key, value):
+        cls.__env_backup[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    @classmethod
+    def restore_environment_variable(cls, key):
+        original_value = cls.__env_backup.get(key)
+
+        if original_value is None:
+            del os.environ[key]
+        else:
+            os.environ[key] = original_value
+
+
+class CloudTestFile(TestFile, EnvironmentMutationMixin):
     storage_provider = ""
     key_env_name = ""
     secret_env_name = ""
 
     _storage_container = "okpycloudfilestest{}".format(random.randint(0, 100000))
-
-    __env_backup = {}
 
     @classmethod
     def setUpClass(cls):
@@ -67,20 +83,6 @@ class CloudTestFile(TestFile):
 
     def verify_download_headers(self, headers, filename, content_type):
         pass
-
-    @classmethod
-    def set_environment_variable(cls, key, value):
-        cls.__env_backup[key] = os.environ.get(key)
-        os.environ[key] = value
-
-    @classmethod
-    def restore_environment_variable(cls, key):
-        original_value = cls.__env_backup.get(key)
-
-        if original_value is None:
-            del os.environ[key]
-        else:
-            os.environ[key] = original_value
 
 
 class GoogleCloudTestFile(CloudTestFile):

--- a/tests/test_files_cloud.py
+++ b/tests/test_files_cloud.py
@@ -37,7 +37,9 @@ class CloudTestFile(TestFile):
             raise unittest.SkipTest("Cloud storage credentials for {} not configured".format(cls.storage_provider))
 
     def create_app(self):
+        self.original_storage_provider = os.environ.get("STORAGE_PROVIDER")
         os.environ["STORAGE_PROVIDER"] = self.storage_provider
+
         os.environ["STORAGE_KEY"] = self.storage_key
         os.environ["STORAGE_SECRET"] = self.storage_secret
         os.environ.setdefault("STORAGE_CONTAINER", "okpycloudfilestest{}".format(random.randint(0, 100000)))
@@ -47,7 +49,11 @@ class CloudTestFile(TestFile):
     def tearDown(self):
         super().tearDown()
 
-        del os.environ["STORAGE_PROVIDER"]
+        if self.original_storage_provider is not None:
+            os.environ["STORAGE_PROVIDER"] = self.original_storage_provider
+        else:
+            del os.environ["STORAGE_PROVIDER"]
+
         del os.environ["STORAGE_KEY"]
         del os.environ["STORAGE_SECRET"]
         del os.environ["STORAGE_CONTAINER"]


### PR DESCRIPTION
In order to facilitate onboarding of new storage backends in the future (e.g. Azure Blob Storage), this pull request refactors the existing tests for the local storage backend to also run for cloud storage backends.

The integration tests are disabled by default. For Google Cloud Storage, the integration tests can be enabled by setting the environment variables `GCP_STORAGE_KEY` and `GCP_STORAGE_SECRET`.

This pull request also fixes two edge-cases in the storage implementation that were uncovered by the tests:

1) The use of `datetime.strftime('%s')` relies on platform-specific undocumented behavior and may not work across Python versions or deployment environments. This was switched to a cross-platform way of converting a datetime to epoch via `datetime.timestamp()`.

2) Submitting malicious files to Google Cloud Storage returned a 400 error rejecting the file. To mirror the behavior of the local storage provider, "special" parts of files uploaded to non-local storage such as `.` and `..` now get sanitized to underscores.

Furthermore, the pull request also:

3) Updates to the latest version of apache-libcloud which improves handling of missing files. Without this update, fetching non-existing blobs produces a 302 result and `test_malicious_local_get_blob` fails.

4) Adds new tests to verify the results of binary downloads (previously only text downloads were verified).

5) Disables parallel test execution on CircleCI. The cloud storage tests rely on mutating environment variables before creation of the Flask app which means that the tests are no longer guaranteed to be threadsafe.

All the changes described above can be found in d16b5ac. The commit depends on 42e40d6 which introduces more parameterization to the test settings such that the storage backend used during the tests can be configured via environment variables.

The pull request also contains a number of additional minor fixes:
- 3b273be and 0ff08d0: Remove creation of directories in settings module and instead ensure that the storage module always creates a container if it doesn't yet exist.
- 0559126: Add SQLite journal file to git-ignore to avoid committing the binary file (e.g during long tests runs).
- aff57b6: Remove direct usage of pytest for exception checking and instead use standard unittest like the rest of the tests in the project.
