### PR TITLE
Transfer OAuth Client Ownership

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1351,12 +1351,17 @@ def client(client_id):
     courses, current_course = get_courses()
 
     client = Client.query.get(client_id)
+    # Show the client owner's email in edit form when owner exists
+    client.owner = client.user.email if client.user else ""
     form = forms.EditClientForm(obj=client)
     # Hide the active field and scopes if not an admin
     if not current_user.is_admin:
         del form.active
         del form.default_scopes
     if form.validate_on_submit():
+        # Be careful not to overwrite user data
+        if not form.user_id.data or not form.user.data:
+            del form.user_id, form.user
         form.populate_obj(client)
         if form.roll_secret.data:
             client.client_secret = utils.generate_secret_key()

--- a/server/forms.py
+++ b/server/forms.py
@@ -618,8 +618,7 @@ class EditClientForm(ClientForm):
             # User isn't changing set to None to avoid overwriting in model
             self.user.data = None
             self.user_id.data = None
-            return True
-        return False
+        return not is_error
 
 class NewCourseForm(BaseForm):
     offering = StringField('Offering (example: cal/cs61a/sp16)',

--- a/server/forms.py
+++ b/server/forms.py
@@ -564,9 +564,24 @@ class EditClientForm(ClientForm):
             description='Whether this client is active and available to be used.',
             default=False,
             )
+    owner = EmailField(
+        'Owner Email',
+        description='''Must be a valid email of OK account with 
+            staff access in some course. (Current owner will lose access if changed.)''',
+        validators=[validators.optional(), validators.email()]
+    )
+    user = HiddenField(
+        description="Do not fill out or render.",
+        validators=[validators.optional()]
+    )
+    user_id = HiddenField(
+        description="Do not fill out or render.",
+        validators=[validators.optional()]
+    )
     roll_secret = BooleanField(
         'Change the secret?',
-        description='Should the secret be changed? If checked, the new value will appear after submission',
+        description='''Should the secret be changed? If checked,
+            the new value will appear after submission''',
         default=False)
     client_secret = HiddenField(
         'Placeholder for secret',
@@ -578,16 +593,33 @@ class EditClientForm(ClientForm):
         super(ClientForm, self).__init__(obj=obj, **kwargs)
 
     def validate(self):
+        is_error = False
         # if our validators do not pass
         if not super(ClientForm, self).validate():
-            return False
+            is_error = True
         if self.client_id.data != self.obj.client_id:
             existing_client = Client.query.filter_by(client_id=self.client_id.data).first()
             if existing_client:
                 self.client_id.errors.append('That client ID already exists')
-                return False
-        return True
-
+                is_error = True
+        if self.owner.data != self.obj.owner:
+            user = User.query.filter_by(email=self.owner.data).one_or_none()
+            if not user:
+                self.owner.errors.append("Email does not exist.")
+                is_error = True
+            elif not user.is_staff():
+                self.owner.errors.append('New owner must be a some course staff member.')
+                is_error = True
+            elif not is_error:
+                # New user is valid so populate necessary attributes to update model
+                self.user.data = user
+                self.user_id.data = user.id
+        elif not is_error:
+            # User isn't changing set to None to avoid overwriting in model
+            self.user.data = None
+            self.user_id.data = None
+            return True
+        return False
 
 class NewCourseForm(BaseForm):
     offering = StringField('Offering (example: cal/cs61a/sp16)',

--- a/server/templates/staff/edit_client.html
+++ b/server/templates/staff/edit_client.html
@@ -24,6 +24,7 @@
                     <div class="box-body">
                     {% call forms.render_form(form, action_url="", action_text='Update OAuth Client', class_='form') %}
                       {{ forms.render_field(form.name, label_visible=true, placeholder='Ok Client', type='text') }}
+                      {{ forms.render_field(form.owner, label_visible=true, placeholder='Owner Email', type='text') }}
                       {{ forms.render_field(form.description, label_visible=true, placeholder='A client for OK', type='text') }}
                       {{ forms.render_field(form.client_id, label_visible=true, placeholder='ok-client', type='text') }}
                       {{ forms.render_checkbox_field(form.roll_secret, label_visible=true) }}


### PR DESCRIPTION
Existing owner's of OAuth clients as well as admins can now transfer ownership by changing the owner email for the respective OAuth client.

This change attempts to respect the current "ownerless" state of some OAuth clients by allowing them to remain "ownerless" even during future client setting edits.

If the owner is changed however it is verified that the new owner does indeed exist and is a staff member of some course. (Considering if they weren't they would be unable to access the `/admin/client` page to manage the OAuth client.)

Includes three new test cases to cover for attempts at changing the owner email with a non-staff email, nonexistent account and with a valid staff email.

Preview:

<img width="699" alt="image" src="https://user-images.githubusercontent.com/2927722/39276930-264aa328-48a0-11e8-8365-cff554e5e376.png">

Fixes #1249 

