### PR TITLE
Hot Fix Force Flask Version <0.12.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==0.12.0,<0.12.3
+Flask>=0.12.0,<0.12.3
 jinja2==2.9.6
 
 # WSGI Containers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.12,<0.13
+Flask==0.12.2
 jinja2==2.9.6
 
 # WSGI Containers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==0.12.2
+Flask==0.12.0,<0.12.3
 jinja2==2.9.6
 
 # WSGI Containers


### PR DESCRIPTION
The newest flask release `0.12.3` is breaking the build per #1252. Likely there is some issue in how we are using the `Request.get_json()` method that needs to be updated. Additional details in the Flask changelog http://flask.pocoo.org/docs/0.12/changelog/#version-0-12-3

Fixes #1252 

TODO(@colinschoen) Refactor for Flask `0.12.3` compatability. Tracking at #1253