### PR TITLE
Unpin Flask Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.12.0,<0.12.3
+Flask>=0.12.0,<0.13,!=0.12.3 # 0.12.3 is a broken release. Ref: https://github.com/pallets/flask/issues/2728
 jinja2==2.9.6
 
 # WSGI Containers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==0.12.0,<0.12.3
+Flask>=0.12.0,<0.12.3
 jinja2==2.9.6
 
 # WSGI Containers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.12.0,<0.13,!=0.12.3 # 0.12.3 is a broken release. Ref: https://github.com/pallets/flask/issues/2728
+Flask>=0.12,<0.13,!=0.12.3 # 0.12.3 is a broken release. Ref: https://github.com/pallets/flask/issues/2728
 jinja2==2.9.6
 
 # WSGI Containers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.12,<0.13
+Flask==0.12.2
 jinja2==2.9.6
 
 # WSGI Containers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==0.12.2
+Flask==0.12.0,<0.12.3
 jinja2==2.9.6
 
 # WSGI Containers


### PR DESCRIPTION
Flask 0.12.3 is a broken release. This removes the hotfix (#1254)
of pinning the Flask version and prevents usage of the
dirty version 0.12.3

Ref: pallets/flask#2728

Fixes #1253 