### PR TITLE
Refactoring the settings config to remove duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ _cache/*
 database.db
 *.db
 *.db-journal
+
+# Visual Studio Code
+.vscode

--- a/manage.py
+++ b/manage.py
@@ -16,7 +16,7 @@ from server.extensions import assets_env, cache
 
 # default to dev config
 env = os.environ.get('OK_ENV', 'dev')
-app = create_app('settings/{0!s}.py'.format(env))
+app = create_app(env)
 
 migrate = Migrate(app, db)
 manager = Manager(app)

--- a/server/settings/_base.py
+++ b/server/settings/_base.py
@@ -1,0 +1,85 @@
+""" Do not put secrets in this file. This file is public.
+    Production config.
+"""
+import os
+
+from server.settings import RAVEN_IGNORE_EXCEPTIONS as raven_exceptions
+
+# Shared settings across all environments
+
+def initialize_config(cls):
+    cls.initialize_config()
+    return cls
+
+class Config(object):
+    SECRET_KEY = os.getenv('SECRET_KEY')
+    
+    DEBUG = False
+    ASSETS_DEBUG = False
+    TESTING_LOGIN = False
+    DEBUG_TB_INTERCEPT_REDIRECTS = False
+    
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    REDIS_PORT = 6379
+    RQ_POLL_INTERVAL = 2000
+    RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
+        os.getenv('REDIS_HOST', 'localhost')
+
+    STORAGE_SERVER = False
+
+    RAVEN_IGNORE_EXCEPTIONS = raven_exceptions
+
+    # Service Keys
+    GOOGLE = {
+        'consumer_key': os.environ.get('GOOGLE_ID'),
+        'consumer_secret':  os.environ.get('GOOGLE_SECRET')
+    }
+
+    SENDGRID_AUTH = {
+        'user': os.environ.get("SENDGRID_USER"),
+        'key': os.environ.get("SENDGRID_KEY")
+    }
+
+    @classmethod
+    def initialize_config(cls):
+        db_url = os.getenv('DATABASE_URL')
+        if db_url:
+            if 'mysql' in db_url:
+                db_url = db_url.replace('mysql://', 'mysql+pymysql://')
+                db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+
+                #This defends against people copy/pasting a connection URL that doesn't include any query parameters 
+                # (in which case the following code creates a bad URI)
+                if '?' not in db_url:
+                    db_url += '?'
+        else:
+            db_url = cls.get_default_db_url()
+
+        cls.SQLALCHEMY_DATABASE_URI = db_url
+
+        # If using sqlite use absolute path (otherwise we break migrations)
+        sqlite_prefix = 'sqlite:///'
+        if cls.SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
+            cls.SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
+                    os.path.abspath(cls.SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
+
+
+        cls.STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'LOCAL')
+        cls.STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER', os.path.abspath("./local-storage"))
+        cls.STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
+        cls.STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
+
+        if cls.STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(cls.STORAGE_CONTAINER):
+            os.makedirs(cls.STORAGE_CONTAINER)
+
+        cls.verify_oauth_credentials()
+
+
+    @classmethod
+    def get_default_db_url(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def verify_oauth_credentials(cls):
+        raise NotImplementedError

--- a/server/settings/_devbase.py
+++ b/server/settings/_devbase.py
@@ -1,0 +1,14 @@
+# Shared settings across dev and test
+
+class Config(object):
+    ASSETS_DEBUG = True
+    TESTING_LOGIN = True
+    INSTANTCLICK = True
+
+    CACHE_TYPE = 'simple'
+
+    GOOGLE_CONSUMER_KEY = ''
+
+    @classmethod
+    def verify_oauth_credentials(cls):
+        pass

--- a/server/settings/_prodbase.py
+++ b/server/settings/_prodbase.py
@@ -1,0 +1,24 @@
+import os
+
+# Shared settings across prod, staging and simple
+
+class Config(object):
+    SENTRY_USER_ATTRS = ['email', 'name']
+    PREFERRED_URL_SCHEME = 'https'
+    OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 28800
+
+    WTF_CSRF_CHECK_DEFAULT = True
+    WTF_CSRF_ENABLED = True
+    
+    CACHE_TYPE = 'simple'
+    CACHE_KEY_PREFIX = 'ok-web'
+
+    RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
+        os.getenv('REDIS_HOST', 'redis-master')
+
+    STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',  'ok-v3-user-files')
+
+    @classmethod
+    def verify_oauth_credentials(cls):
+        if "GOOGLE_ID" not in os.environ or "GOOGLE_SECRET" not in os.environ:
+            print("Warning: the google login variables are not set.")

--- a/server/settings/dev.py
+++ b/server/settings/dev.py
@@ -1,47 +1,18 @@
 import os
 
-ENV = 'dev'
-SECRET_KEY = os.getenv('OK_SESSION_KEY', 'changeinproductionkey')
-CACHE_TYPE = 'simple'
+from server.settings._base import Config as BaseConfig, initialize_config
+from server.settings._devbase import Config as DevBaseConfig
 
-DEBUG = True
-ASSETS_DEBUG = True
-TESTING_LOGIN = True
-DEBUG_TB_INTERCEPT_REDIRECTS = False
-INSTANTCLICK = True
+@initialize_config
+class Config(DevBaseConfig, BaseConfig):
+    ENV = 'dev'
+    
+    SECRET_KEY = os.getenv('OK_SESSION_KEY', 'changeinproductionkey')
 
-SQLALCHEMY_TRACK_MODIFICATIONS = False
-db_url = os.getenv('DATABASE_URL')
-if db_url:
-    if 'mysql' in db_url:
-        db_url = db_url.replace('mysql://', 'mysql+pymysql://')
-        db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-    SQLALCHEMY_DATABASE_URI = db_url
-else:
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///../oksqlite.db'
-# SQLALCHEMY_ECHO = True
+    DEBUG = True
 
-# If using sqlite use absolute path (otherwise we break migrations)
-sqlite_prefix = 'sqlite:///'
-if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
-    SQLALCHEMY_DATABASE_URI = (sqlite_prefix + 
-            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
+    MAX_CONTENT_LENGTH = 20 * 1024 * 1024  # Max Upload Size is 20MB
 
-
-RQ_DEFAULT_HOST = REDIS_HOST = 'localhost'
-REDIS_PORT = 6379
-RQ_POLL_INTERVAL = 2000
-
-MAX_CONTENT_LENGTH = 20 * 1024 * 1024  # Max Upload Size is 20MB
-
-STORAGE_PROVIDER = os.environ.get('STORAGE_PROVIDER',  'LOCAL')
-STORAGE_SERVER = False
-STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',
-                                   os.path.abspath("./local-storage"))
-STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
-STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
-
-if STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(STORAGE_CONTAINER):
-    os.makedirs(STORAGE_CONTAINER)
-
-GOOGLE_CONSUMER_KEY = ''
+    @classmethod
+    def get_default_db_url(cls):
+        return 'sqlite:///../oksqlite.db'

--- a/server/settings/prod.py
+++ b/server/settings/prod.py
@@ -4,78 +4,27 @@
 import os
 import sys
 
-from server.settings import RAVEN_IGNORE_EXCEPTIONS
+from server.settings._base import Config as BaseConfig, initialize_config
+from server.settings._prodbase import Config as ProdBaseConfig
 
-ENV = 'prod'
-PREFERRED_URL_SCHEME = 'https'
+@initialize_config
+class Config(ProdBaseConfig, BaseConfig):
+    ENV = 'prod'
 
-SECRET_KEY = os.getenv('SECRET_KEY')
+    STORAGE_PROVIDER = os.environ.get('STORAGE_PROVIDER',  'GOOGLE_STORAGE')
 
-DEBUG = False
-ASSETS_DEBUG = False
-TESTING_LOGIN = False
-DEBUG_TB_INTERCEPT_REDIRECTS = False
-# The Google Cloud load balancer behaves like two proxies: one with the external
-# fowarding rule IP, and one with an internal IP.
-# See https://cloud.google.com/compute/docs/load-balancing/http/#target_proxies
-# Including Nginx too makes 3 proxies.
-NUM_PROXIES = 3
+    MAX_CONTENT_LENGTH = 30 * 1024 * 1024  # Max Upload Size is 30MB
 
-db_url = os.getenv('DATABASE_URL')
-if db_url:
-    db_url = db_url.replace('mysql://', 'mysql+pymysql://')
-    db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-else:
-    print("The database URL is not set!")
-    sys.exit(1)
+    CACHE_TYPE = 'redis'
 
-SQLALCHEMY_DATABASE_URI = db_url
+    # The Google Cloud load balancer behaves like two proxies: 
+    # one with the external fowarding rule IP, and
+    # one with an internal IP.
+    # See https://cloud.google.com/compute/docs/load-balancing/http/#target_proxies
+    # Including Nginx too makes 3 proxies.
+    NUM_PROXIES = 3
 
-# If using sqlite use absolute path (otherwise we break migrations)
-sqlite_prefix = 'sqlite:///'
-if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
-    SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
-            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
-
-SQLALCHEMY_TRACK_MODIFICATIONS = False
-SENTRY_USER_ATTRS = ['email', 'name']
-PREFERRED_URL_SCHEME = 'https'
-OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 28800
-
-WTF_CSRF_CHECK_DEFAULT = True
-WTF_CSRF_ENABLED = True
-
-MAX_CONTENT_LENGTH = 30 * 1024 * 1024  # Max Upload Size is 30MB
-
-CACHE_TYPE = 'redis'
-CACHE_KEY_PREFIX = 'ok-web'
-
-RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
-    os.getenv('REDIS_HOST', 'redis-master')
-REDIS_PORT = 6379
-RQ_POLL_INTERVAL = 2000
-
-STORAGE_PROVIDER = os.environ.get('STORAGE_PROVIDER',  'GOOGLE_STORAGE')
-STORAGE_SERVER = False
-STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',  'ok-v3-user-files')
-STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
-STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
-
-try:
-    os.environ["GOOGLE_ID"]
-    os.environ["GOOGLE_SECRET"]
-except KeyError:
-    print("Please set the google login variables.")
-    sys.exit(1)
-
-# Service Keys
-
-GOOGLE = {
-    'consumer_key': os.environ.get('GOOGLE_ID'),
-    'consumer_secret':  os.environ.get('GOOGLE_SECRET')
-}
-
-SENDGRID_AUTH = {
-    'user': os.environ.get("SENDGRID_USER"),
-    'key': os.environ.get("SENDGRID_KEY")
-}
+    @classmethod
+    def get_default_db_url(cls):
+        print("The database URL is not set!")
+        sys.exit(1)

--- a/server/settings/simple.py
+++ b/server/settings/simple.py
@@ -2,74 +2,19 @@
     Production config.
 """
 import os
-import sys
 
-from server.settings import RAVEN_IGNORE_EXCEPTIONS
+from server.settings._base import Config as BaseConfig, initialize_config
+from server.settings._prodbase import Config as ProdBaseConfig
 
-ENV = 'simple'
-PREFERRED_URL_SCHEME = 'http'
+@initialize_config
+class Config(ProdBaseConfig, BaseConfig):
+    ENV = 'simple'
 
-SECRET_KEY = os.getenv('SECRET_KEY')
+    PREFERRED_URL_SCHEME = 'http'
 
-DEBUG = False
-ASSETS_DEBUG = False
-TESTING_LOGIN = False
-DEBUG_TB_INTERCEPT_REDIRECTS = False
+    RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
+        os.getenv('REDIS_HOST', 'localhost')
 
-db_url = os.getenv('DATABASE_URL')
-if db_url:
-    if 'mysql' in db_url:
-        db_url = db_url.replace('mysql://', 'mysql+pymysql://')
-        db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-else:
-    print("The database URL is not set!")
-    db_url = os.getenv('SQLALCHEMY_URL', 'sqlite:///../oksqlite.db')
-
-SQLALCHEMY_DATABASE_URI = db_url
-
-# If using sqlite use absolute path (otherwise we break migrations)
-sqlite_prefix = 'sqlite:///'
-if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
-    SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
-            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
-
-SQLALCHEMY_TRACK_MODIFICATIONS = False
-SENTRY_USER_ATTRS = ['email', 'name']
-PREFERRED_URL_SCHEME = 'https'
-OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 28800
-
-WTF_CSRF_CHECK_DEFAULT = True
-WTF_CSRF_ENABLED = True
-
-CACHE_TYPE = 'simple'
-CACHE_KEY_PREFIX = 'ok-web'
-
-RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
-    os.getenv('REDIS_HOST', '127.0.0.1')
-REDIS_PORT = 6379
-RQ_POLL_INTERVAL = 2000
-
-STORAGE_PROVIDER = 'LOCAL'
-STORAGE_SERVER = False
-STORAGE_CONTAINER = os.path.abspath("./local-storage")
-
-if not os.path.exists(STORAGE_CONTAINER):
-    os.makedirs(STORAGE_CONTAINER)
-try:
-    os.environ["GOOGLE_ID"]
-    os.environ["GOOGLE_SECRET"]
-except KeyError:
-    print("Please set the google login variables.")
-    sys.exit(1)
-
-# Service Keys
-
-GOOGLE = {
-    'consumer_key': os.environ.get('GOOGLE_ID'),
-    'consumer_secret':  os.environ.get('GOOGLE_SECRET')
-}
-
-SENDGRID_AUTH = {
-    'user': os.environ.get("SENDGRID_USER"),
-    'key': os.environ.get("SENDGRID_KEY")
-}
+    @classmethod
+    def get_default_db_url(cls):
+        return os.getenv('SQLALCHEMY_URL', 'sqlite:///../oksqlite.db')

--- a/server/settings/staging.py
+++ b/server/settings/staging.py
@@ -2,74 +2,16 @@
     For staging environment (Using Dokku)
 """
 import os
-import sys
 
-from server.settings import RAVEN_IGNORE_EXCEPTIONS
+from server.settings._base import Config as BaseConfig, initialize_config
+from server.settings._prodbase import Config as ProdBaseConfig
 
-ENV = 'staging'
-PREFERRED_URL_SCHEME = 'https'
+@initialize_config
+class Config(ProdBaseConfig, BaseConfig):
+    ENV = 'staging'
 
-SECRET_KEY = os.getenv('SECRET_KEY')
+    MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # Max Upload Size is 10MB
 
-CACHE_TYPE = 'simple'
-
-DEBUG = False
-ASSETS_DEBUG = False
-TESTING_LOGIN = False
-DEBUG_TB_INTERCEPT_REDIRECTS = False
-
-SQLALCHEMY_TRACK_MODIFICATIONS = False
-SENTRY_USER_ATTRS = ['email', 'name']
-
-RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
-    os.getenv('REDIS_HOST', 'redis-master')
-REDIS_PORT = 6379
-RQ_POLL_INTERVAL = 2000
-OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 28800
-
-db_url = os.getenv('DATABASE_URL')
-if db_url:
-    db_url = db_url.replace('mysql://', 'mysql+pymysql://')
-    db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-
-else:
-    db_url = os.getenv('SQLALCHEMY_URL', 'sqlite:///../oksqlite.db')
-
-SQLALCHEMY_DATABASE_URI = db_url
-
-# If using sqlite use absolute path (otherwise we break migrations)
-sqlite_prefix = 'sqlite:///'
-if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
-    SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
-            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
-
-
-WTF_CSRF_CHECK_DEFAULT = True
-WTF_CSRF_ENABLED = True
-MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # Max Upload Size is 10MB
-
-STORAGE_PROVIDER = os.environ.get('STORAGE_PROVIDER',  'LOCAL')
-STORAGE_SERVER = False
-STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',  'ok-v3-user-files')
-STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
-STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
-
-if STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(STORAGE_CONTAINER):
-    os.makedirs(STORAGE_CONTAINER)
-
-try:
-    os.environ["GOOGLE_ID"]
-    os.environ["GOOGLE_SECRET"]
-except KeyError:
-    print("Please set the google login variables. source secrets.sh")
-    sys.exit(1)
-
-GOOGLE = {
-    'consumer_key': os.environ.get('GOOGLE_ID'),
-    'consumer_secret':  os.environ.get('GOOGLE_SECRET')
-}
-
-SENDGRID_AUTH = {
-    'user': os.environ.get("SENDGRID_USER"),
-    'key': os.environ.get("SENDGRID_KEY")
-}
+    @classmethod
+    def get_default_db_url(cls):
+        return os.getenv('SQLALCHEMY_URL', 'sqlite:///../oksqlite.db')

--- a/server/settings/test.py
+++ b/server/settings/test.py
@@ -1,48 +1,18 @@
 import os
 
-ENV = 'test'
-SECRET_KEY = os.getenv('OK_SESSION_KEY', 'testkey')
+from server.settings._base import Config as BaseConfig, initialize_config
+from server.settings._devbase import Config as DevBaseConfig
 
-DEBUG = False
-ASSETS_DEBUG = True
-TESTING_LOGIN = True
-DEBUG_TB_INTERCEPT_REDIRECTS = False
-INSTANTCLICK = False
+@initialize_config
+class Config(DevBaseConfig, BaseConfig):
+    ENV = 'test'
 
-SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SECRET_KEY = os.getenv('OK_SESSION_KEY', 'testkey')
 
-db_url = os.getenv('DATABASE_URL')
-if db_url and 'mysql' in db_url:
-    db_url = db_url.replace('mysql://', 'mysql+pymysql://')
-    db_url += "&sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-else:
-    db_url = os.getenv('DATABASE_URL', 'sqlite:///../oktest.db')
+    WTF_CSRF_CHECK_DEFAULT = False
+    WTF_CSRF_ENABLED = False
+    RQ_DEFAULT_DB = 2  # to prevent conflicts with development
 
-SQLALCHEMY_DATABASE_URI = db_url
-
-# If using sqlite use absolute path (otherwise we break migrations)
-sqlite_prefix = 'sqlite:///'
-if SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
-    SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
-            os.path.abspath(SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
-
-WTF_CSRF_CHECK_DEFAULT = False
-WTF_CSRF_ENABLED = False
-
-STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'LOCAL')
-STORAGE_SERVER = False
-STORAGE_CONTAINER = os.getenv('STORAGE_CONTAINER', os.path.abspath('./local-storage'))
-STORAGE_KEY = os.getenv('STORAGE_KEY', '')
-STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
-
-if STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(STORAGE_CONTAINER):
-    os.makedirs(STORAGE_CONTAINER)
-
-CACHE_TYPE = 'simple'
-
-RQ_DEFAULT_HOST = REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-REDIS_PORT = 6379
-RQ_POLL_INTERVAL = 2000
-RQ_DEFAULT_DB = 2  # to prevent conflicts with development
-
-GOOGLE_CONSUMER_KEY = ''
+    @classmethod
+    def get_default_db_url(cls):
+        return os.getenv('SQLALCHEMY_URL', 'sqlite:///../oktest.db')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,7 +13,7 @@ from server import constants
 
 class OkTestCase(TestCase):
     def create_app(self):
-        return create_app('settings/test.py')
+        return create_app('test')
 
     def setUp(self):
         db.drop_all()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -79,7 +79,7 @@ if driver:
             models.db.session.commit()
 
         def create_app(self):
-            app = create_app('settings/test.py')
+            app = create_app('test')
             # Default port is 5000
             app.config['LIVESERVER_PORT'] = 8943
             return app

--- a/worker.py
+++ b/worker.py
@@ -11,7 +11,7 @@ from server import create_app
 if __name__ == '__main__':
     # default to dev config
     env = os.environ.get('OK_ENV', 'dev')
-    app = create_app('settings/{0!s}.py'.format(env))
+    app = create_app(env)
     with app.app_context():
         worker = get_worker()
         sentry_dsn = os.getenv('SENTRY_DSN')

--- a/wsgi.py
+++ b/wsgi.py
@@ -5,4 +5,4 @@ import os
 from server import create_app
 
 env = os.environ.get('OK_ENV', 'dev')
-app = create_app('settings/{0!s}.py'.format(env))
+app = create_app(env)


### PR DESCRIPTION
There are many shared settings between the environment setting files, this commit creates a base class that is shared across all environments; a prodbase class which contains settings shared across simple, staging and prod; and a devbase class which has settings shared across dev and test. The individual env setting files then inherit from the bases and overwrite as needed.