### PR TITLE
Add support for Azure Blobs storage backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.5-alpine
 
-RUN apk add --update patch ca-certificates nginx perl;
+RUN apk add --update patch ca-certificates nginx perl musl-dev openssl-dev libffi-dev python-dev gcc;
 
 RUN mkdir /code/
 WORKDIR /code/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ RUN pip3 --timeout=60 install --no-cache-dir -r requirements.txt
 
 ADD . .
 
-RUN mv docker/nginx/nginx.conf /etc/nginx/nginx.conf
-RUN mv docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+RUN mv docker/nginx/nginx.conf /etc/nginx/nginx.conf && \
+    mv docker/nginx/default.conf /etc/nginx/conf.d/default.conf && \
+    mv docker/wait-for /wait-for
 
 RUN ./manage.py assets build
 

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,15 +1,17 @@
-web:
-  image: cs61a/ok-server
-  restart: 'no'
-  command: >
-    sh -c '
-      /wait-for db:3306 redis:6379 &&
-      py.test --cov-report term-missing --cov=server tests/
-    '
-  environment:
-    OK_ENV: 'test'
-    DATABASE_URL: 'mysql://okdev:okdev@db:3306/okdev?charset=utf8mb4'
-    REDIS_HOST: 'redis'
-  links:
-    - db
-    - redis
+version: '2'
+
+services:
+
+  web:
+    image: cs61a/ok-server
+    restart: 'no'
+    command: >
+      sh -c '/wait-for db:3306 redis:6379 &&
+             py.test --cov-report term-missing --cov=server tests/'
+    environment:
+      OK_ENV: 'test'
+      DATABASE_URL: 'mysql://okdev:okdev@db:3306/okdev?charset=utf8mb4'
+      REDIS_HOST: 'redis'
+    links:
+      - db
+      - redis

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,7 +1,11 @@
 web:
   image: cs61a/ok-server
   restart: 'no'
-  command: py.test --cov-report term-missing --cov=server tests/
+  command: >
+    sh -c '
+      /wait-for db:3306 redis:6379 &&
+      py.test --cov-report term-missing --cov=server tests/
+    '
   environment:
     OK_ENV: 'test'
     DATABASE_URL: 'mysql://okdev:okdev@db:3306/okdev?charset=utf8mb4'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,23 +1,31 @@
-web:
-  image: cs61a/ok-server
-  build: ..
-  restart: always
-  command: /bin/bash -c "./manage.py resetdb && ./manage.py server"
-  ports:
-    - "80:5000"
-  volumes:
-    - ..:/code
-  links:
-    - db
-    - redis
-db:
-  image: mysql:5.7
-  restart: always
-  environment:
-    MYSQL_USER: 'okdev'
-    MYSQL_PASSWORD: 'okdev'
-    MYSQL_DATABASE: 'okdev'
-    MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-redis:
-  image: redis:alpine
-  restart: always
+version: '2'
+
+services:
+
+  web:
+    image: cs61a/ok-server
+    build: ..
+    restart: always
+    command: /bin/bash -c "./manage.py resetdb && ./manage.py server"
+    ports:
+      - "80:5000"
+    volumes:
+      - ..:/code
+    links:
+      - db
+      - redis
+
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_USER: 'okdev'
+      MYSQL_PASSWORD: 'okdev'
+      MYSQL_DATABASE: 'okdev'
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    tmpfs:
+      - /var/lib/mysql
+
+  redis:
+    image: redis:alpine
+    restart: always

--- a/docker/wait-for
+++ b/docker/wait-for
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Script taken from https://github.com/vnegrisolo/wait-for
+
+log() {
+  echo "[wait-for] [`date +'%Y%m%d%H%M%S'`] $@"
+}
+
+usage() {
+  echo "Usage: `basename "$0"` [--timeout=15] <HOST>:<PORT> [<HOST_2>:<PORT_2>]"
+}
+
+unknown_arg() {
+  log "[ERROR] unknown argument: '$@'"
+  usage
+  exit 2
+}
+
+wait_for() {
+  timeout=$1 && host=$2 && port=$3
+  log "wait '$host':'$port' up to '$timeout'"
+  for i in `seq $timeout` ; do
+    if nc -z "$host" "$port" > /dev/null 2>&1 ; then
+      log "wait finish '$host:$port' [`expr $(date +%s) - $START`] seconds"
+      exit 0
+    fi
+    log "wait attempt '${host}:${port}' [$i]"
+    sleep 1
+  done
+  log "[ERROR] wait timeout of '$timeout' on '$host:$port'"
+  exit 1
+}
+
+trap 'kill $(jobs -p) &>/dev/null' EXIT
+
+START=$(date +%s)
+timeout=15
+pids=""
+for i in $@ ; do
+  case $i in
+    --timeout=*) timeout="${i#*=}" ;;
+    -t=*) timeout="${i#*=}" ;;
+    *:* )
+      wait_for "$timeout" "${i%%:*}" "${i##*:}" &
+      pids="$pids $!"
+    ;;
+    *) unknown_arg "$i" ;;
+  esac
+done
+
+status=0
+for pid in $pids; do
+  if ! wait $pid ; then
+    status=1
+  fi
+done
+
+log "wait done with status=$status"
+exit $status

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,9 @@ Flask-Login==0.4.0
 
 # File Storage
 lockfile==0.12.2 # For local storage
-apache-libcloud==2.3.0
+# apache-libcloud==2.3.0
+# Branch that contains a fix for Azure stream blob upload - use until a fix for https://issues.apache.org/jira/projects/LIBCLOUD/issues/LIBCLOUD-993 is published
+https://github.com/jmspring/libcloud/archive/issue_933_azure_crash_v2.3.0-base.zip
 
 # OAuth
 
@@ -78,6 +80,9 @@ gcloud==0.18.3
 
 # Azure logging
 applicationinsights==0.11.3
+
+# Azure Storage
+azure-storage-blob==1.1.0
 
 # Development
 Flask-DebugToolbar==0.10.1

--- a/server/storage.py
+++ b/server/storage.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode, urljoin
 from werkzeug.utils import secure_filename
 from libcloud.storage.types import Provider
 from libcloud.storage.providers import get_driver
+from azure.storage.blob import BlockBlobService, BlobPermissions
 
 logger = logging.getLogger(__name__)
 
@@ -108,12 +109,12 @@ class Storage:
         """
         driver_name = self.driver.name.lower()
         if 's3' in driver_name:
-            base_url = 'https://%s'.format(self.driver.connection.host)
+            base_url = 'https://{}'.format(self.driver.connection.host)
             url = urljoin(base_url, object_path)
         elif 'google' in driver_name:
             url = urljoin('https://storage.googleapis.com', object_path)
         elif 'azure' in driver_name:
-            base_url = 'https://%s.blob.core.windows.net'.format(self.driver.key)
+            base_url = 'https://{}.blob.core.windows.net'.format(self.driver.key)
             url = urljoin(base_url, object_path)
         else:
             raise Exception('Unsupported Storage Driver for URL')
@@ -126,14 +127,25 @@ class Storage:
         if container_name is None:
             container_name = self.container_name
         driver_name = self.driver.name.lower()
-        expires = (dt.datetime.now() + dt.timedelta(seconds=timeout))
-        expires = int(expires.timestamp())
+        expiry_timestamp = (dt.datetime.now() + dt.timedelta(seconds=timeout)).timestamp()
 
         if 's3' in driver_name or 'google' in driver_name:
             keyIdName = "AWSAccessKeyId" if "s3" in driver_name else "GoogleAccessId"
+            return self._generate_google_aws_signed_url(keyIdName, obj_name, expiry_timestamp)
+        elif 'azure' in driver_name:
+            return self._generate_azure_signed_url(obj_name, expiry_timestamp)
         else:
             raise Exception('{0} does not support signed urls'.format(driver_name))
 
+    def get_object_stream(self, object):
+        """ Data stream of the libcloud object.
+        """
+        return self.driver.download_object_as_stream(object)
+
+    def _generate_google_aws_signed_url(self, keyIdName, obj_name, expiry_timestamp):
+        """ Generates a signed URL compatible with Google Cloud and AWS S3
+        """
+        expires = int(expiry_timestamp)
         obj_path = "{0}/{1}".format(self.container.name, obj_name)
         s2s = ("GET\n\n\n{expires}\n/{object_name}"
                .format(expires=expires, object_name=obj_path).encode('utf-8'))
@@ -148,7 +160,24 @@ class Storage:
         secure_url = self.get_url(obj_path)
         return "{0}?{1}".format(secure_url, url_kv)
 
-    def get_object_stream(self, object):
-        """ Data stream of the libcloud object.
+    def _generate_azure_signed_url(self, obj_name, expiry_timestamp):
+        """ Generates a signed URL compatible with Azure Blob Storage
         """
-        return self.driver.download_object_as_stream(object)
+        # libcloud encodes the access key, so it needs decoding
+        secret_as_string = base64.b64encode(self.driver.secret).decode()
+
+        # azure expiry times need to be ISO8601 (no milliseconds, and with the timezone character)
+        expires = dt.datetime.utcfromtimestamp(expiry_timestamp).replace(microsecond=0).isoformat() + 'Z'
+
+        blob_service = BlockBlobService(self.driver.key, secret_as_string)
+
+        signed_url = blob_service.make_blob_url(
+            self.container.name,
+            obj_name,
+            sas_token=blob_service.generate_blob_shared_access_signature(
+                self.container.name,
+                obj_name,
+                permission=BlobPermissions(read=True),
+                expiry=expires))
+
+        return signed_url


### PR DESCRIPTION
To enable the Azure Blobs storage [1] backend, set the following
environment variables:

```
STORAGE_PROVIDER=AZURE_BLOBS
STORAGE_KEY={AzureStorageAccountName}
STORAGE_SECRET={AzureStorageSecretKey}
STORAGE_CONTAINER=okpyfiles
```

Note that, just like the GCP storage backend, the Azure Blobs storage
backend assumes that the storage container already exists. This
assumption could be relaxed (by modifying the code to create a container
on the fly) since for Azure Storage, the account name and key are enough
to create a new container programmatically. However, this would conflict
with the current implementation of GCP storage since its permissions
don't allow for container creation.

There are two follow-up fixes that will be contributed in the future:

- Moving the logic to create the signed access signature into libcloud
  and removing the dependency on the azure-storage module from OK.
  @martinpeck will work on the libcloud feature pull request.

- Re-enable the `test_simple` after the `download_object_as_stream`
  method is fixed for Azure Blobs in libcloud. Note that this test
  is currently only meaningful for the local storage provider so the
  current disabling the test is not a risk for OK. @jmspring will
  work on the libcloud fix.

[1] https://azure.microsoft.com/en-gb/services/storage/blobs/