### PR TITLE
Compares timestamps with assertAlmostEqual

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -32,6 +32,8 @@ ASSIGNMENT_ENDPOINT_FORMAT = COURSE_ENDPOINT_FORMAT[:-1] + '/\w+$'
 GRADES_BUCKET = 'ok_grades_bucket'
 TIMEZONE = 'America/Los_Angeles'
 ISO_DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
+ISO_DATETIME_FMT_WITH_T = '%Y-%m-%dT%H:%M:%S'
+ISO_DATETIME_FMT_WITH_T_WITH_SECONDS_FRAC = "{}.%f".format(ISO_DATETIME_FMT_WITH_T)
 
 AUTOGRADER_URL = 'https://autograder.cs61a.org'
 

--- a/server/constants.py
+++ b/server/constants.py
@@ -32,8 +32,6 @@ ASSIGNMENT_ENDPOINT_FORMAT = COURSE_ENDPOINT_FORMAT[:-1] + '/\w+$'
 GRADES_BUCKET = 'ok_grades_bucket'
 TIMEZONE = 'America/Los_Angeles'
 ISO_DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
-ISO_DATETIME_FMT_WITH_T = '%Y-%m-%dT%H:%M:%S'
-ISO_DATETIME_FMT_WITH_T_WITH_SECONDS_FRAC = "{}.%f".format(ISO_DATETIME_FMT_WITH_T)
 
 AUTOGRADER_URL = 'https://autograder.cs61a.org'
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -145,7 +145,7 @@ class TestApi(OkTestCase):
         del response_json['created']
         del response_json['submission_time']
         del response_json['messages'][0]['created']
-        assert response.json['data'] == {
+        assert response_json == {
             "submitter": user_json,
             "submit": backup.submit,
             "group": [user_json],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,10 +132,10 @@ class TestApi(OkTestCase):
         }
         response_json = response.json['data']
         time_threshold = dt.timedelta(seconds=5)
-        self.assertAlmostEqual(dt.atetime.strptime(response_json['created'], constants.ISO_DATETIME_FMT_WITH_T),
+        self.assertAlmostEqual(dt.datetime.strptime(response_json['created'], constants.ISO_DATETIME_FMT_WITH_T),
                                backup.created,
                                delta=time_threshold)
-        self.assertAlmostEqual(dt.daetime.strptime(response_json['submission_time'], constants.ISO_DATETIME_FMT_WITH_T_WITH_SECONDS_FRAC),
+        self.assertAlmostEqual(dt.datetime.strptime(response_json['submission_time'], constants.ISO_DATETIME_FMT_WITH_T_WITH_SECONDS_FRAC),
                                submission_time,
                                delta=time_threshold)
         self.assertAlmostEqual(dt.datetime.strptime(response_json['messages'][0]['created'], constants.ISO_DATETIME_FMT_WITH_T),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import dateutil.parser
 import json
 import random
 
@@ -132,13 +133,13 @@ class TestApi(OkTestCase):
         }
         response_json = response.json['data']
         time_threshold = dt.timedelta(seconds=5)
-        self.assertAlmostEqual(dt.datetime.strptime(response_json['created'], constants.ISO_DATETIME_FMT_WITH_T),
+        self.assertAlmostEqual(dateutil.parser.parse(response_json['created']),
                                backup.created,
                                delta=time_threshold)
-        self.assertAlmostEqual(dt.datetime.strptime(response_json['submission_time'], constants.ISO_DATETIME_FMT_WITH_T_WITH_SECONDS_FRAC),
+        self.assertAlmostEqual(dateutil.parser.parse(response_json['submission_time']),
                                submission_time,
                                delta=time_threshold)
-        self.assertAlmostEqual(dt.datetime.strptime(response_json['messages'][0]['created'], constants.ISO_DATETIME_FMT_WITH_T),
+        self.assertAlmostEqual(dateutil.parser.parse(response_json['messages'][0]['created']),
                                backup.created,
                                delta=time_threshold)
         # Unset timestamps already tested.


### PR DESCRIPTION
The test_get_backup test has been flaking due to
doing equality comparisons on timestamps before
and after database transactions. These comparisons
have been changed to ensuring the timestamps are
within a certain threshold (currently 5 seconds).

Fixes #1255

Signed-off-by: Colin Schoen <cschoen@berkeley.edu>