### PR TITLE
Ensure that all settings match old values

### DIFF
--- a/server/settings/_base.py
+++ b/server/settings/_base.py
@@ -3,8 +3,6 @@
 """
 import os
 
-from server.settings import RAVEN_IGNORE_EXCEPTIONS as raven_exceptions
-
 # Shared settings across all environments
 
 def initialize_config(cls):
@@ -23,23 +21,14 @@ class Config(object):
 
     REDIS_PORT = 6379
     RQ_POLL_INTERVAL = 2000
-    RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
+    RQ_DEFAULT_HOST = REDIS_HOST = \
         os.getenv('REDIS_HOST', 'localhost')
 
     STORAGE_SERVER = False
-
-    RAVEN_IGNORE_EXCEPTIONS = raven_exceptions
-
-    # Service Keys
-    GOOGLE = {
-        'consumer_key': os.environ.get('GOOGLE_ID'),
-        'consumer_secret':  os.environ.get('GOOGLE_SECRET')
-    }
-
-    SENDGRID_AUTH = {
-        'user': os.environ.get("SENDGRID_USER"),
-        'key': os.environ.get("SENDGRID_KEY")
-    }
+    STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'LOCAL')
+    STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER', os.path.abspath("./local-storage"))
+    STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
+    STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
 
     @classmethod
     def initialize_config(cls):
@@ -63,12 +52,6 @@ class Config(object):
         if cls.SQLALCHEMY_DATABASE_URI.startswith(sqlite_prefix):
             cls.SQLALCHEMY_DATABASE_URI = (sqlite_prefix +
                     os.path.abspath(cls.SQLALCHEMY_DATABASE_URI[len(sqlite_prefix) + 1:]))
-
-
-        cls.STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'LOCAL')
-        cls.STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER', os.path.abspath("./local-storage"))
-        cls.STORAGE_KEY = os.environ.get('STORAGE_KEY', '')
-        cls.STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
 
         if cls.STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(cls.STORAGE_CONTAINER):
             os.makedirs(cls.STORAGE_CONTAINER)

--- a/server/settings/_devbase.py
+++ b/server/settings/_devbase.py
@@ -3,7 +3,6 @@
 class Config(object):
     ASSETS_DEBUG = True
     TESTING_LOGIN = True
-    INSTANTCLICK = True
 
     CACHE_TYPE = 'simple'
 

--- a/server/settings/_prodbase.py
+++ b/server/settings/_prodbase.py
@@ -1,5 +1,7 @@
 import os
 
+from server.settings import RAVEN_IGNORE_EXCEPTIONS as raven_exceptions
+
 # Shared settings across prod, staging and simple
 
 class Config(object):
@@ -11,12 +13,24 @@ class Config(object):
     WTF_CSRF_ENABLED = True
     
     CACHE_TYPE = 'simple'
-    CACHE_KEY_PREFIX = 'ok-web'
 
     RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
         os.getenv('REDIS_HOST', 'redis-master')
 
     STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',  'ok-v3-user-files')
+
+    RAVEN_IGNORE_EXCEPTIONS = raven_exceptions
+
+    # Service Keys
+    GOOGLE = {
+        'consumer_key': os.environ.get('GOOGLE_ID'),
+        'consumer_secret':  os.environ.get('GOOGLE_SECRET')
+    }
+
+    SENDGRID_AUTH = {
+        'user': os.environ.get("SENDGRID_USER"),
+        'key': os.environ.get("SENDGRID_KEY")
+    }
 
     @classmethod
     def verify_oauth_credentials(cls):

--- a/server/settings/dev.py
+++ b/server/settings/dev.py
@@ -6,8 +6,10 @@ from server.settings._devbase import Config as DevBaseConfig
 @initialize_config
 class Config(DevBaseConfig, BaseConfig):
     ENV = 'dev'
-    
+
     SECRET_KEY = os.getenv('OK_SESSION_KEY', 'changeinproductionkey')
+
+    INSTANTCLICK = True
 
     DEBUG = True
 

--- a/server/settings/prod.py
+++ b/server/settings/prod.py
@@ -16,6 +16,7 @@ class Config(ProdBaseConfig, BaseConfig):
     MAX_CONTENT_LENGTH = 30 * 1024 * 1024  # Max Upload Size is 30MB
 
     CACHE_TYPE = 'redis'
+    CACHE_KEY_PREFIX = 'ok-web'
 
     # The Google Cloud load balancer behaves like two proxies: 
     # one with the external fowarding rule IP, and

--- a/server/settings/simple.py
+++ b/server/settings/simple.py
@@ -10,10 +10,12 @@ from server.settings._prodbase import Config as ProdBaseConfig
 class Config(ProdBaseConfig, BaseConfig):
     ENV = 'simple'
 
-    PREFERRED_URL_SCHEME = 'http'
-
     RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
         os.getenv('REDIS_HOST', 'localhost')
+
+    CACHE_KEY_PREFIX = 'ok-web'
+
+    STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER', os.path.abspath("./local-storage"))
 
     @classmethod
     def get_default_db_url(cls):

--- a/server/settings/staging.py
+++ b/server/settings/staging.py
@@ -12,6 +12,8 @@ class Config(ProdBaseConfig, BaseConfig):
 
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # Max Upload Size is 10MB
 
+    STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER', os.path.abspath("./local-storage"))
+
     @classmethod
     def get_default_db_url(cls):
         return os.getenv('SQLALCHEMY_URL', 'sqlite:///../oksqlite.db')


### PR DESCRIPTION
This fixes a regression introduced in ec06b9c where the settings were refactored into a class hierarchy but some values were changed by accident as part of this refactor.

The fix was verified by logging out the configs on the commit before the refactor, applying the refactor, logging out the configs again and then diffing the results.

Snippet used to log the configs:

```py
with open('config-' + app.config['ENV'] + '.txt', 'w') as fobj:
    config = str(app.config).replace(', ', ',\n')
    fobj.write(config)
```

Paired with @liliankasem