### PR TITLE
Adding option to login using Azure Active Directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,8 @@ Flask-RESTful==0.3.5
 Flask-Testing>=0.5.0,<1.0
 Flask-RQ==0.2
 
+pyjwt==1.6.1
+
 # Flask DB Extensions
 # Flask-SQLAlchemy==2.2
 # Fork of Flask-SQLAlchemy==2.2 that supports custom create_engine paramters - use until https://github.com/mitsuhiko/flask-sqlalchemy/issues/166 is resolved

--- a/server/constants.py
+++ b/server/constants.py
@@ -48,6 +48,10 @@ FORBIDDEN_ROUTE_NAMES = [
 ]
 FORBIDDEN_ASSIGNMENT_NAMES = []
 
+# Service Providers
+GOOGLE = "GOOGLE"
+MICROSOFT = "MICROSOFT"
+
 # Maximum file size to show in browser, in characters
 DIFF_SIZE_LIMIT = 64 * 1024  # 64KB
 SOURCE_SIZE_LIMIT = 10 * 1024 * 1024 # 10MB

--- a/server/controllers/auth.py
+++ b/server/controllers/auth.py
@@ -1,7 +1,7 @@
 """
 There are two ways to authenticate a request:
 * Present the session cookie returned after logging in
-* Send a Google access token as the access_token query parameter
+* Send an access token as the access_token query parameter to the chosen service provider
 """
 import jwt
 
@@ -20,6 +20,7 @@ import logging
 from server import utils
 from server.models import db, User, Enrollment, Client, Token, Grant
 from server.extensions import csrf, oauth_provider, cache
+from server.constants import GOOGLE, MICROSOFT
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ def record_params(setup_state):
     global oauth
     oauth = OAuth()
     app = setup_state.app
-    provider_name = app.config.get('OAUTH_PROVIDER', 'GOOGLE')
+    provider_name = app.config.get('OAUTH_PROVIDER', GOOGLE)
     provider_auth = oauth.remote_app(
         provider_name, 
         app_key=provider_name
@@ -120,6 +121,7 @@ def google_user_data(token, timeout=5):
     return None
 
 def microsoft_user_data(token):
+    """ Query Microsoft for a user's info. """
     if not token:
         logger.info("Microsoft Token is None")
         return None
@@ -131,16 +133,16 @@ def microsoft_user_data(token):
         if 'preferred_username' in decoded_token:  # Azure V2 endpoints
             return {'email': decoded_token['preferred_username']}
 
-        logger.error("Unable to retrieve unique_name from token - which is email")
+        logger.error("Unable to retrieve unique_name (the user's email) from token")
         return None
     except jwt.DecodeError as e:
-        logger.error("jwt Decode error from token")
+        logger.error("jwt decode error from token")
         logger.error('Decode error was %s', e)
         return None
 
 def user_from_provider_token(token):
     """
-    Get a User with the given Google access token, or create one if no User with
+    Get a User with the given access token, or create one if no User with
     this email is found. If the token is invalid, return None.
     """
     if not token:
@@ -148,18 +150,17 @@ def user_from_provider_token(token):
     if use_testing_login() and token == "test":
         return user_from_email("okstaff@okpy.org")
 
-    if provider_name == 'GOOGLE':
+    if provider_name == GOOGLE:
         user_data = google_user_data(token)
-    elif provider_name == 'MICROSOFT':
+    elif provider_name == MICROSOFT:
         user_data = microsoft_user_data(token)
 
     if not user_data or 'email' not in user_data:
-        cache.delete_memoized(google_user_data, token)
-        logger.warning("Could not login with oauth. Trying again - {}".format(user_data))
-        user_data = google_user_data(token, timeout=10)
+        if provider_name == GOOGLE:
+            cache.delete_memoized(google_user_data, token)
+        elif provider_name == MICROSOFT:
+            cache.delete_memoized(microsoft_user_data, token)
 
-    if not user_data or 'email' not in user_data:
-        cache.delete_memoized(google_user_data, token)
         logger.warning("Auth Retry failed for token {} - {}".format(token, user_data))
         return None
 
@@ -191,7 +192,7 @@ def unauthorized():
 
 def authorize_user(user):
     if user is None:
-        logger.error("Google Auth Failure - attempting to authorize None user")
+        logger.error("Auth Failure - attempting to authorize None user")
         raise TypeError("Cannot login as None")
     login_user(user)
     after_login = session.pop('after_login', None)
@@ -199,7 +200,7 @@ def authorize_user(user):
 
 def use_testing_login():
     """
-    Return True if we use the unsecure testing login instead of Google OAuth.
+    Return True if we use the unsecure testing login instead of service provider OAuth.
     Requires TESTING_LOGIN = True in the config and the environment is not prod.
     """
     return (current_app.config.get('TESTING_LOGIN', False) and
@@ -221,7 +222,7 @@ def csrf_check():
 @auth.route("/login/")
 def login():
     """
-    Authenticates a user with an access token using Google APIs.
+    Authenticates a user with an access token using service provider APIs.
     """
     if use_testing_login():
         return redirect(url_for('.testing_login'))
@@ -255,17 +256,10 @@ def authorized():
         return redirect("/")
 
     logger.info("Login from {}".format(user.email))
-    expires_in = safe_cast(resp.get('expires_in'), int, 0)
+    expires_in = utils.safe_cast(resp.get('expires_in'), int, 0)
     session['token_expiry'] = dt.datetime.now() + dt.timedelta(seconds=expires_in)
     session['provider_token'] = (access_token, '')  # (access_token, secret)
     return authorize_user(user)
-
-
-def safe_cast(val, to_type, default=None):
-    try:
-        return to_type(val)
-    except (ValueError, TypeError):
-        return default
 
 ################
 # Other Routes #
@@ -286,7 +280,7 @@ def sudo_login(email):
     return authorize_user(user)
 
 # Backdoor log in if you want to impersonate a user.
-# Will not give you a Google auth token.
+# Will not give you a service provider auth token.
 # Requires that TESTING_LOGIN = True in the config and we must not be running in prod.
 @auth.route('/testing-login/')
 def testing_login():

--- a/server/settings/_base.py
+++ b/server/settings/_base.py
@@ -31,6 +31,42 @@ class Config(object):
     STORAGE_SECRET = os.environ.get('STORAGE_SECRET', '').replace('\\n', '\n')
 
     APPINSIGHTS_INSTRUMENTATIONKEY = os.getenv('APPINSIGHTS_INSTRUMENTATIONKEY')
+    
+    # Service Keys
+    GOOGLE = dict(
+        consumer_key=os.environ.get('GOOGLE_ID'),
+        consumer_secret=os.environ.get('GOOGLE_SECRET'),
+        base_url='https://www.googleapis.com/oauth2/v3/',
+        access_token_url='https://accounts.google.com/o/oauth2/token',
+        authorize_url='https://accounts.google.com/o/oauth2/auth',
+        profile_url="https://www.googleapis.com/plus/v1/people/me?access_token={}",
+        userinfo_url="https://www.googleapis.com/oauth2/v3/userinfo?access_token={}",
+        request_token_params={
+            'scope': 'email',
+            'prompt': 'select_account'
+        },
+        request_token_url=None,
+        access_token_method='POST'
+    )
+
+    MICROSOFT = dict(
+        consumer_key=os.environ.get('MICROSOFT_APP_ID'),
+        consumer_secret=os.environ.get('MICROSOFT_APP_SECRET'),
+        tenent_id=os.environ.get('MICROSOFT_TENANT_ID', 'common'),
+        base_url='https://management.azure.com',
+        request_token_url=None,
+        access_token_method='POST',
+        access_token_url='https://login.microsoftonline.com/{tenant_id}/oauth2/token' \
+            .format(tenant_id=os.environ.get('MICROSOFT_TENANT_ID', 'common')),
+        authorize_url='https://login.microsoftonline.com/{tenant_id}/oauth2/authorize' \
+            .format(tenant_id=os.environ.get('MICROSOFT_TENANT_ID', 'common')),
+        request_token_params={
+            'resource' : os.environ.get('MICROSOFT_APP_ID'),
+            'response_mode' : 'query',
+            # 'scope': 'email profile',
+            'prompt': 'login'
+        }
+    )
 
     @classmethod
     def initialize_config(cls):

--- a/server/settings/_prodbase.py
+++ b/server/settings/_prodbase.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from server.settings import RAVEN_IGNORE_EXCEPTIONS as raven_exceptions
 
@@ -21,12 +22,6 @@ class Config(object):
 
     RAVEN_IGNORE_EXCEPTIONS = raven_exceptions
 
-    # Service Keys
-    GOOGLE = {
-        'consumer_key': os.environ.get('GOOGLE_ID'),
-        'consumer_secret':  os.environ.get('GOOGLE_SECRET')
-    }
-
     SENDGRID_AUTH = {
         'user': os.environ.get("SENDGRID_USER"),
         'key': os.environ.get("SENDGRID_KEY")
@@ -34,5 +29,10 @@ class Config(object):
 
     @classmethod
     def verify_oauth_credentials(cls):
-        if "GOOGLE_ID" not in os.environ or "GOOGLE_SECRET" not in os.environ:
-            print("Warning: the google login variables are not set.")
+        if "GOOGLE_ID" in os.environ or "GOOGLE_SECRET" in os.environ:
+            OAUTH_PROVIDER = 'GOOGLE'
+        elif "MICROSOFT_APP_ID" in os.environ or "MICROSOFT_APP_SECRET" in os.environ:
+            OAUTH_PROVIDER = 'MICROSOFT'
+        else:
+            print("Please set the Google or Microsoft OAuth ID and Secret variables.")
+            sys.exit(1)

--- a/server/utils.py
+++ b/server/utils.py
@@ -293,3 +293,11 @@ def check_url(url):
         return True
     except Exception:
         return False
+
+# Safe Cast
+
+def safe_cast(val, to_type, default=None):
+    try:
+        return to_type(val)
+    except (ValueError, TypeError):
+        return default


### PR DESCRIPTION
This commit enables the optional use of Azure Active Directory to login to okpy. The default auth method will be Google (we check for the Google ID and secret first before looking for Microsoft variables).

To get Microsoft auth working you have to have Azure Active Directory setup and provide the follow environment variables:

```
MICROSOFT_TENANT_ID
MICROSOFT_APP_SECRET
MICROSOFT_APP_ID
```

- MICROSOFT_TENANT_ID: Retrieve from Azure Portal under the Active Directory blade, then Properties. TENAND_ID can be the domain name of the Active Directory. So either a custom domain or the assigned foobar.onmicrosoft.com one
- MICROSOFT_APP_ID: This is from the Application registered in the Azure AD Tenant. Again, from the Azure AD blade on the portal go to Registered Applications
- MICROSOFT_APP_SECRET: For that same APP_ID, you must generate a secret which is also under Registered Application Settings.

NB: Make sure to remove the GOOGLE_ID and GOOGLE_SECRET environment variables as this is the first thing we look for.