### PR TITLE
Ensure that make and docker share the same image

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,4 +1,5 @@
 web:
+  image: cs61a/ok-server
   restart: 'no'
   command: py.test --cov-report term-missing --cov=server tests/
   environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,5 @@
 web:
+  image: cs61a/ok-server
   build: ..
   restart: always
   command: /bin/bash -c "./manage.py resetdb && ./manage.py server"


### PR DESCRIPTION
Currently the `make docker-build` command creates a custom tagged image called `cs61a/ok-server`. The `make docker-test` command, on the other hand, delegates to docker-compose which will assign its own image name based on the service name declared in the compose file (`web`).

This means that in some situations docker-compose will unnecessarily rebuild the image. Specifying an explicit image name in the compose file eliminates this inconsistency and ensures that both make recipes (`make docker-build` and `make docker-test`) will always use the same image.