### PR TITLE
Fix unittest warnings

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -315,22 +315,22 @@ class TestApi(OkTestCase):
         response = self.client.get(endpoint)
         self.assert_200(response)
         backups = response.json['data']['backups']
-        self.assertEquals(len(backups), 1)
+        self.assertEqual(len(backups), 1)
         self.assertTrue('submission_time' in backups[0])
-        self.assertEquals(backups[0]['submission_time'], backups[0]['created'])
-        self.assertEquals(response.json['data']['count'], 1)
-        self.assertEquals(response.json['data']['limit'], 150)
-        self.assertEquals(response.json['data']['offset'], 0)
-        self.assertEquals(response.json['data']['has_more'], False)
+        self.assertEqual(backups[0]['submission_time'], backups[0]['created'])
+        self.assertEqual(response.json['data']['count'], 1)
+        self.assertEqual(response.json['data']['limit'], 150)
+        self.assertEqual(response.json['data']['offset'], 0)
+        self.assertEqual(response.json['data']['has_more'], False)
 
         response = self.client.get(endpoint + "?offset=20&limit=2")
         self.assert_200(response)
         backups = response.json['data']['backups']
-        self.assertEquals(len(backups), 0)
-        self.assertEquals(response.json['data']['count'], 1)
-        self.assertEquals(response.json['data']['limit'], 2)
-        self.assertEquals(response.json['data']['offset'], 20)
-        self.assertEquals(response.json['data']['has_more'], False)
+        self.assertEqual(len(backups), 0)
+        self.assertEqual(response.json['data']['count'], 1)
+        self.assertEqual(response.json['data']['limit'], 2)
+        self.assertEqual(response.json['data']['offset'], 20)
+        self.assertEqual(response.json['data']['has_more'], False)
 
     def test_export_final(self):
         self._test_backup(True)
@@ -346,23 +346,23 @@ class TestApi(OkTestCase):
         response = self.client.get(endpoint)
         self.assert_200(response)
         backups = response.json['data']['backups']
-        self.assertEquals(len(backups), 1)
-        self.assertEquals(backups[0]['is_late'], False)
-        self.assertEquals(len(backups[0]['group']), 1)
-        self.assertEquals(backups[0]['group'][0]['email'], self.user1.email)
-        self.assertEquals(len(backups[0]['messages']), 1)
+        self.assertEqual(len(backups), 1)
+        self.assertEqual(backups[0]['is_late'], False)
+        self.assertEqual(len(backups[0]['group']), 1)
+        self.assertEqual(backups[0]['group'][0]['email'], self.user1.email)
+        self.assertEqual(len(backups[0]['messages']), 1)
 
-        self.assertEquals(response.json['data']['count'], 1)
-        self.assertEquals(response.json['data']['has_more'], False)
-        self.assertEquals(response.json['data']['offset'], 0)
+        self.assertEqual(response.json['data']['count'], 1)
+        self.assertEqual(response.json['data']['has_more'], False)
+        self.assertEqual(response.json['data']['offset'], 0)
 
         response = self.client.get(endpoint + '?offset=1')
         self.assert_200(response)
         backups = response.json['data']['backups']
-        self.assertEquals(len(backups), 0)
-        self.assertEquals(response.json['data']['count'], 1)
-        self.assertEquals(response.json['data']['has_more'], False)
-        self.assertEquals(response.json['data']['offset'], 1)
+        self.assertEqual(len(backups), 0)
+        self.assertEqual(response.json['data']['count'], 1)
+        self.assertEqual(response.json['data']['has_more'], False)
+        self.assertEqual(response.json['data']['offset'], 1)
 
     def test_assignment_api(self):
         self._test_backup(True)
@@ -383,7 +383,7 @@ class TestApi(OkTestCase):
         self.login(self.staff1.email)
         response = self.client.get(endpoint)
         self.assert_200(response)
-        self.assertEquals(response.json['data']['name'], self.assignment.name)
+        self.assertEqual(response.json['data']['name'], self.assignment.name)
 
         # Hidden assignment, but should be visible to staff
         self.assignment.visible = False
@@ -417,7 +417,7 @@ class TestApi(OkTestCase):
         response = self.client.get(endpoint)
         self.assert_200(response)
         members = response.json['data']['members']
-        self.assertEquals(len(members), 2)
+        self.assertEqual(len(members), 2)
         assert 'email' in members[0]['user']
 
         # Make sure user2 can access user1's endpoint
@@ -425,7 +425,7 @@ class TestApi(OkTestCase):
         response = self.client.get(endpoint)
         self.assert_200(response)
         members = response.json['data']['members']
-        self.assertEquals(len(members), 2)
+        self.assertEqual(len(members), 2)
         assert 'email' in members[1]['user']
 
 
@@ -434,7 +434,7 @@ class TestApi(OkTestCase):
 
         self.assert_200(response)
         members = response.json['data']['members']
-        self.assertEquals(len(members), 2)
+        self.assertEqual(len(members), 2)
         assert 'email' in  members[0]['user']
 
         # Login as some random user
@@ -539,9 +539,9 @@ class TestApi(OkTestCase):
             self.login(self.user1.email)
             response = self.client.get(comment_url)
             self.assert_200(response)
-            self.assertEquals(len(response['data']['comments']), 2)
-            self.assertEquals(response['data']['comments'][0].message, 'hello world')
-            self.assertEquals(response['data']['comments'][1].message, 'wow')
+            self.assertEqual(len(response['data']['comments']), 2)
+            self.assertEqual(response['data']['comments'][0].message, 'hello world')
+            self.assertEqual(response['data']['comments'][1].message, 'wow')
             self.logout()
 
             #check to see if staff can access comments
@@ -586,8 +586,8 @@ class TestApi(OkTestCase):
         self.assert_200(specific)
 
         members = current.json['data']['participations']
-        self.assertEquals(len(members), 1)
-        self.assertEquals(current.json['data'], specific.json['data'])
+        self.assertEqual(len(members), 1)
+        self.assertEqual(current.json['data'], specific.json['data'])
 
         # Staff don't get permission
         self.login(self.staff1.email)
@@ -606,7 +606,7 @@ class TestApi(OkTestCase):
         current, specific = test_both_endpoints(student)
         self.assert_200(current)
         self.assert_200(specific)
-        self.assertEquals(specific.json['data']['email'], student.email)
+        self.assertEqual(specific.json['data']['email'], student.email)
 
         # Lab Assistants don't have access
         self.login(self.lab_assistant1.email)
@@ -624,7 +624,7 @@ class TestApi(OkTestCase):
         response = self.client.get(student_endpoint)
         self.assert_200(response)
         student_emails = [s['email'] for s in response.json['data']['student']]
-        self.assertEquals(self.user1.email in student_emails, True)
+        self.assertEqual(self.user1.email in student_emails, True)
         self.login(self.user1.email)
         response = self.client.get(student_endpoint)
         self.assert_403(response)
@@ -638,8 +638,8 @@ class TestApi(OkTestCase):
         anon_response = self.client.get(student_endpoint)
         self.assert_200(anon_response)
         active_assignments = len([a for a in self.course.assignments if a.active])
-        self.assertEquals(active_assignments, len(anon_response.json['data']['assignments']))
+        self.assertEqual(active_assignments, len(anon_response.json['data']['assignments']))
         self.login(self.staff1.email)
         auth_response = self.client.get(student_endpoint)
         self.assert_200(auth_response)
-        self.assertEquals(anon_response.json['data'], auth_response.json['data'])
+        self.assertEqual(anon_response.json['data'], auth_response.json['data'])

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -38,8 +38,8 @@ class TestDownload(OkTestCase):
         response = self.client.get(url)
         self.assert_200(response)
         self.assertTrue('attachment' in response.headers['Content-Disposition'])
-        self.assertEquals(response.headers['Content-Type'], 'text/plain; charset=UTF-8')
-        self.assertEquals(response.headers['X-Content-Type-Options'], 'nosniff')
+        self.assertEqual(response.headers['Content-Type'], 'text/plain; charset=UTF-8')
+        self.assertEqual(response.headers['X-Content-Type-Options'], 'nosniff')
         self.assertEqual(contents, response.data.decode('UTF-8'))
 
     def test_raw(self):
@@ -52,8 +52,8 @@ class TestDownload(OkTestCase):
         response = self.client.get(url)
         self.assert_200(response)
         self.assertTrue('inline' in response.headers['Content-Disposition'])
-        self.assertEquals(response.headers['Content-Type'], 'text/plain; charset=UTF-8')
-        self.assertEquals(response.headers['X-Content-Type-Options'], 'nosniff')
+        self.assertEqual(response.headers['Content-Type'], 'text/plain; charset=UTF-8')
+        self.assertEqual(response.headers['X-Content-Type-Options'], 'nosniff')
         self.assertEqual(contents, response.data.decode('UTF-8'))
 
     def test_incorrect_hash(self):

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -71,7 +71,7 @@ class TestEffortGrading(OkTestCase):
         except AssertionError:
             effort = 0
         print(effort)
-        self.assertEquals(effort, score)
+        self.assertEqual(effort, score)
 
     def test_effort_grading(self):
         """

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -53,7 +53,7 @@ class TestExtension(OkTestCase):
 
     def test_extension_basic(self):
         ext = self._make_ext(self.assignment, self.user1)
-        self.assertEquals(ext, Extension.get_extension(self.user1, self.assignment))
+        self.assertEqual(ext, Extension.get_extension(self.user1, self.assignment))
         self.assertFalse(Extension.get_extension(self.user2, self.assignment))
 
     def test_extension_permissions(self):
@@ -63,7 +63,7 @@ class TestExtension(OkTestCase):
 
     def test_extension_expiry(self):
         ext = self._make_ext(self.assignment, self.user1)
-        self.assertEquals(ext, Extension.get_extension(self.user1, self.assignment))
+        self.assertEqual(ext, Extension.get_extension(self.user1, self.assignment))
         ext.expires = dt.datetime.utcnow() - dt.timedelta(days=1)
         self.assertFalse(Extension.get_extension(self.user1, self.assignment))
 
@@ -76,8 +76,8 @@ class TestExtension(OkTestCase):
         self.set_offset(-1) # Lock assignment
 
         ext = self._make_ext(self.assignment, self.user1)
-        self.assertEquals(ext, Extension.get_extension(self.user1, self.assignment))
-        self.assertEquals(ext, Extension.get_extension(self.user2, self.assignment))
+        self.assertEqual(ext, Extension.get_extension(self.user1, self.assignment))
+        self.assertEqual(ext, Extension.get_extension(self.user2, self.assignment))
         # User 3 has not accepted yet so does not get an extension
         self.assertFalse(Extension.get_extension(self.user3, self.assignment))
 
@@ -90,7 +90,7 @@ class TestExtension(OkTestCase):
         # Should fail because it's late.
         self._submit_to_api(self.user1, False)
         num_backups = Backup.query.filter(Backup.submitter_id == self.user1.id).count()
-        self.assertEquals(num_backups, 1) # Failed submissions are still collected.
+        self.assertEqual(num_backups, 1) # Failed submissions are still collected.
 
         ext = self._make_ext(self.assignment, self.user1)
         # Should allow submission after the submission
@@ -100,7 +100,7 @@ class TestExtension(OkTestCase):
         backup = Backup.query.filter(Backup.submitter_id == self.user1.id,
                                      Backup.submit == True).first()
         self.assertIsNotNone(backup)
-        self.assertEquals(backup.custom_submission_time, ext.custom_submission_time)
+        self.assertEqual(backup.custom_submission_time, ext.custom_submission_time)
 
         # Others should still not be able to submit
         self._submit_to_api(self.user2, False)
@@ -118,7 +118,7 @@ class TestExtension(OkTestCase):
         backup = Backup.query.filter(Backup.submitter_id == self.user1.id,
                                      Backup.submit == True).first()
         self.assertIsNotNone(backup)
-        self.assertEquals(backup.custom_submission_time,
+        self.assertEqual(backup.custom_submission_time,
                              ext.custom_submission_time)
 
     def test_group_submit_with_extension(self):
@@ -169,7 +169,7 @@ class TestExtension(OkTestCase):
         second_back = Backup.query.filter(Backup.submitter_id == self.user2.id,
                                           Backup.submit == True).first()
         # The submission from User 2 should have a custom submission time
-        self.assertEquals(second_back.custom_submission_time, ext.custom_submission_time)
+        self.assertEqual(second_back.custom_submission_time, ext.custom_submission_time)
 
     def test_extension_after_backups(self):
         """ Backups from before the extension was made should use the extension

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -44,13 +44,13 @@ class TestFile(OkTestCase):
         delete_silently(self.blob2)
 
     def test_simple(self):
-        self.assertEquals(self.blob1.driver.key, storage.driver.key)
-        self.assertEquals(self.blob1.container.name, storage.container_name)
-        self.assertEquals(self.blob1.container.name, self.file1.container)
-        self.assertEquals(self.blob1.name, self.file1.object_name)
+        self.assertEqual(self.blob1.driver.key, storage.driver.key)
+        self.assertEqual(self.blob1.container.name, storage.container_name)
+        self.assertEqual(self.blob1.container.name, self.file1.container)
+        self.assertEqual(self.blob1.name, self.file1.object_name)
         blob_stream = storage.get_object_stream(self.blob1)
         with open(CWD + "/files/fizzbuzz_after.py", 'rb') as f:
-            self.assertEquals(b''.join(blob_stream), f.read())
+            self.assertEqual(b''.join(blob_stream), f.read())
 
     def test_duplicate_overwrite(self):
         with open(CWD + "/files/fizzbuzz_after.py", 'rb') as f:
@@ -59,9 +59,9 @@ class TestFile(OkTestCase):
                                                course_id=self.course.id)
             duplicate_obj = duplicate.object()
 
-        self.assertEquals(self.blob1.driver.key, duplicate_obj.driver.key)
-        self.assertEquals(self.file1.filename, duplicate.filename)
-        self.assertEquals(self.blob1.name, duplicate_obj.name)
+        self.assertEqual(self.blob1.driver.key, duplicate_obj.driver.key)
+        self.assertEqual(self.file1.filename, duplicate.filename)
+        self.assertEqual(self.blob1.name, duplicate_obj.name)
         duplicate_obj.delete()
 
     def test_prefix(self):
@@ -72,11 +72,11 @@ class TestFile(OkTestCase):
                                                course_id=self.course.id)
             prefix_obj = prefix.object()
 
-        self.assertEquals(self.blob1.driver.key, prefix_obj.driver.key)
-        self.assertEquals(self.blob1.container.name, prefix.container)
-        self.assertEquals(self.blob1.name, self.file1.object_name)
-        self.assertEquals(prefix_obj.name, self.test_prefix_expected_obj_name)
-        self.assertEquals(prefix.filename, 'fizz.txt')
+        self.assertEqual(self.blob1.driver.key, prefix_obj.driver.key)
+        self.assertEqual(self.blob1.container.name, prefix.container)
+        self.assertEqual(self.blob1.name, self.file1.object_name)
+        self.assertEqual(prefix_obj.name, self.test_prefix_expected_obj_name)
+        self.assertEqual(prefix.filename, 'fizz.txt')
         prefix_obj.delete()
 
     test_prefix_expected_obj_name = "test_fizz.txt"
@@ -89,11 +89,11 @@ class TestFile(OkTestCase):
                                                course_id=self.course.id)
             prefix_obj = prefix.object()
 
-        self.assertEquals(self.blob1.driver.key, prefix_obj.driver.key)
-        self.assertEquals(self.blob1.container.name, prefix.container)
-        self.assertEquals(self.blob1.name, self.file1.object_name)
-        self.assertEquals(prefix_obj.name, self.test_malicious_directory_traversal_expected_obj_name)
-        self.assertEquals(prefix.filename, 'fizz.txt')
+        self.assertEqual(self.blob1.driver.key, prefix_obj.driver.key)
+        self.assertEqual(self.blob1.container.name, prefix.container)
+        self.assertEqual(self.blob1.name, self.file1.object_name)
+        self.assertEqual(prefix_obj.name, self.test_malicious_directory_traversal_expected_obj_name)
+        self.assertEqual(prefix.filename, 'fizz.txt')
         prefix_obj.delete()
 
     test_malicious_directory_traversal_expected_obj_name = "test_.._.._fizz.txt"
@@ -172,7 +172,7 @@ class TestFile(OkTestCase):
         self.login(self.staff1.email)
         encoded_id = utils.encode_id(self.file2.id)
         url = "/api/v3/file/{0}".format(encoded_id)
-        self.assertEquals(self.file2.download_link, url)
+        self.assertEqual(self.file2.download_link, url)
         headers, data = self.fetch_file(url)
         self.verify_download_headers(headers, self.file2.filename, "image/svg+xml")
         self.verify_binary_download(CWD + "/../server/static/img/logo.svg", data)
@@ -208,9 +208,9 @@ class TestFile(OkTestCase):
         return response.headers, response.data
 
     def verify_download_headers(self, headers, filename, content_type):
-        self.assertEquals(headers["Content-Disposition"], "attachment; filename={0!s}".format(filename))
-        self.assertEquals(headers["Content-Type"], content_type)
-        self.assertEquals(headers["X-Content-Type-Options"], "nosniff")
+        self.assertEqual(headers["Content-Disposition"], "attachment; filename={0!s}".format(filename))
+        self.assertEqual(headers["Content-Type"], content_type)
+        self.assertEqual(headers["X-Content-Type-Options"], "nosniff")
 
     def verify_text_download(self, file_path, downloaded_data):
         with io.open(file_path, "r", encoding="utf-8") as fobj:

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -68,17 +68,17 @@ class TestGrading(OkTestCase):
 
     def test_course_submissions_ids(self):
         students, submissions, no_submission = self._course_submissions_ids(self.assignment)
-        self.assertEquals(sorted(list(students)), [2, 3, 4])
-        self.assertEquals(sorted(list(no_submission)), [5, 6])
-        self.assertEquals(sorted(list(submissions)), [14, 15])
+        self.assertEqual(sorted(list(students)), [2, 3, 4])
+        self.assertEqual(sorted(list(no_submission)), [5, 6])
+        self.assertEqual(sorted(list(submissions)), [14, 15])
         owners_by_backup = [(i, Backup.query.get(i).owners()) for i in submissions]
-        self.assertEquals(sorted(owners_by_backup),  [(14, {2, 3}), (15, {4})])
+        self.assertEqual(sorted(owners_by_backup),  [(14, {2, 3}), (15, {4})])
 
     def test_course_submissions(self):
         students, submissions, no_submission = self._course_submissions_ids(self.assignment)
-        self.assertEquals(sorted(list(students)), [2, 3, 4])
-        self.assertEquals(sorted(list(no_submission)), [5, 6])
-        self.assertEquals(sorted(list(submissions)), [14, 15])
+        self.assertEqual(sorted(list(students)), [2, 3, 4])
+        self.assertEqual(sorted(list(no_submission)), [5, 6])
+        self.assertEqual(sorted(list(submissions)), [14, 15])
 
 
     def test_course_submissions_optimized(self):
@@ -91,35 +91,35 @@ class TestGrading(OkTestCase):
 
         submissions = [fs['backup']['id'] for fs in course_submissions if fs['backup']]
         slow_submissions = [fs['backup']['id'] for fs in slow_course_subms if fs['backup']]
-        self.assertEquals(len(submissions), len(course_subms_filtered))
-        self.assertEquals(len(slow_submissions), len(course_subms_filtered))
+        self.assertEqual(len(submissions), len(course_subms_filtered))
+        self.assertEqual(len(slow_submissions), len(course_subms_filtered))
         print("Running with {}".format(db.engine.name))
 
         if db.engine.name == 'mysql':
             query = self.assignment.mysql_course_submissions_query()
             mysql_data = [d for d in query]
-            self.assertEquals(len(course_submissions), len(mysql_data))
+            self.assertEqual(len(course_submissions), len(mysql_data))
 
             has_submission = sorted(list(fs['user']['id'] for fs in course_submissions
                                  if fs['backup']))
             has_submission_slow = sorted(list(fs['user']['id'] for fs in slow_course_subms
                                       if fs['backup']))
-            self.assertEquals(has_submission, has_submission_slow)
+            self.assertEqual(has_submission, has_submission_slow)
 
             no_subm = sorted(list(fs['user']['id'] for fs in course_submissions
                                  if not fs['backup']))
             no_subm_slow = sorted(list(fs['user']['id'] for fs in slow_course_subms
                                       if not fs['backup']))
-            self.assertEquals(no_subm, no_subm_slow)
+            self.assertEqual(no_subm, no_subm_slow)
 
             backup = sorted(list(fs['backup']['id'] for fs in course_submissions
                                  if fs['backup']))
             backup_slow = sorted(list(fs['backup']['id'] for fs in slow_course_subms
                                       if fs['backup']))
 
-            self.assertEquals(backup, backup_slow)
+            self.assertEqual(backup, backup_slow)
         else:
-            self.assertEquals(slow_course_subms, course_submissions)
+            self.assertEqual(slow_course_subms, course_submissions)
 
 
     def test_flag(self):
@@ -128,11 +128,11 @@ class TestGrading(OkTestCase):
         print("Flagged submission {}".format(submission.id))
 
         students, submissions, no_submission = self._course_submissions_ids(self.assignment)
-        self.assertEquals(sorted(list(students)), [2, 3, 4])
-        self.assertEquals(sorted(list(no_submission)), [5, 6])
-        self.assertEquals(sorted(list(submissions)), [submission.id, 15])
+        self.assertEqual(sorted(list(students)), [2, 3, 4])
+        self.assertEqual(sorted(list(no_submission)), [5, 6])
+        self.assertEqual(sorted(list(submissions)), [submission.id, 15])
         owners_by_backup = [(i, Backup.query.get(i).owners()) for i in submissions]
-        self.assertEquals(sorted(owners_by_backup),  [(submission.id, {2, 3}), (15, {4})])
+        self.assertEqual(sorted(owners_by_backup),  [(submission.id, {2, 3}), (15, {4})])
 
     def test_queue_generation(self):
         students, backups, no_submissions = self._course_submissions_ids(self.assignment)
@@ -141,15 +141,15 @@ class TestGrading(OkTestCase):
                                                self.assignment.id,
                                                self.assignment.course.id,
                                                "Composition")
-        self.assertEquals(len(tasks), 2)
-        self.assertEquals([t.grader.id for t in tasks], [self.staff1.id, self.staff2.id])
+        self.assertEqual(len(tasks), 2)
+        self.assertEqual([t.grader.id for t in tasks], [self.staff1.id, self.staff2.id])
 
         # All backups have been assigned, so should not add any new backups
         tasks = GradingTask.create_staff_tasks(backups, self.active_staff,
                                                self.assignment.id,
                                                self.assignment.course.id,
                                                "Composition")
-        self.assertEquals(len(tasks), 0)
+        self.assertEqual(len(tasks), 0)
 
     def test_view_scores(self):
         self.login(self.staff1.email)
@@ -163,7 +163,7 @@ class TestGrading(OkTestCase):
         response = self.client.get(endpoint)
         self.assert_200(response)
         # No Scores
-        self.assertEquals(response.data, b'time,is_late,email,group,sid,class_account,section,role,assignment_id,kind,score,message,backup_id,grader\n')
+        self.assertEqual(response.data, b'time,is_late,email,group,sid,class_account,section,role,assignment_id,kind,score,message,backup_id,grader\n')
 
     def test_scores_with_generate(self, generate=False):
         if generate:
@@ -191,7 +191,7 @@ class TestGrading(OkTestCase):
         for s in scores:
             backup_creators.extend(s.backup.owners())
 
-        self.assertEquals(len(backup_creators), len(csv_rows) - 1)
+        self.assertEqual(len(backup_creators), len(csv_rows) - 1)
 
 
     def test_publish_grades(self):
@@ -331,27 +331,27 @@ class TestGrading(OkTestCase):
             only_published=False,
         )
         scores.sort(key=lambda score: score.kind)
-        self.assertEquals(len(scores), 2)
+        self.assertEqual(len(scores), 2)
 
         a_score = scores[0]
-        self.assertEquals(a_score.kind, 'composition')
-        self.assertEquals(a_score.score, 10)
-        self.assertEquals(a_score.backup_id, backups2[2].id)
+        self.assertEqual(a_score.kind, 'composition')
+        self.assertEqual(a_score.score, 10)
+        self.assertEqual(a_score.backup_id, backups2[2].id)
 
         b_score = scores[1]
-        self.assertEquals(b_score.kind, 'regrade')
-        self.assertEquals(b_score.score, 8)
-        self.assertEquals(b_score.backup_id, backups2[4].id)
+        self.assertEqual(b_score.kind, 'regrade')
+        self.assertEqual(b_score.score, 8)
+        self.assertEqual(b_score.backup_id, backups2[4].id)
 
         scores = self.assignment.scores([self.user1.id, self.user2.id])
-        self.assertEquals(len(scores), 0)  # no scores have been published
+        self.assertEqual(len(scores), 0)  # no scores have been published
 
         self.assignment.publish_score('composition')
         scores = self.assignment.scores([self.user1.id, self.user2.id])
         scores.sort(key=lambda score: score.kind)
-        self.assertEquals(len(scores), 1)
+        self.assertEqual(len(scores), 1)
 
         a_score = scores[0]
-        self.assertEquals(a_score.kind, 'composition')
-        self.assertEquals(a_score.score, 10)
-        self.assertEquals(a_score.backup_id, backups2[2].id)
+        self.assertEqual(a_score.kind, 'composition')
+        self.assertEqual(a_score.score, 10)
+        self.assertEqual(a_score.backup_id, backups2[2].id)

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -33,9 +33,16 @@ def apply_patch(patch, source):
 class TestHighlight(OkTestCase):
     def setUp(self):
         super(TestHighlight, self).setUp()
+
+        with open('tests/files/difflib_before.py', encoding='utf-8') as fobj:
+            before = fobj.read()
+
+        with open('tests/files/difflib_after.py', encoding='utf-8') as fobj:
+            after = fobj.read()
+
         self.files = {
-            'before.py': open('tests/files/difflib_before.py').read(),
-            'after.py': open('tests/files/difflib_after.py').read(),
+            'before.py': before,
+            'after.py': after,
             'empty.py': '',
             'empty': '',
         }

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -90,7 +90,7 @@ class TestRevision(OkTestCase):
 
         # Ensure that the backup is still accepted
         backups = Backup.query.filter_by(submitter=self.user1).count()
-        self.assertEquals(backups, 2)
+        self.assertEqual(backups, 2)
 
     def test_revison_no_submission(self):
         """ Revisions are not accepted if there is no final submission. """
@@ -100,7 +100,7 @@ class TestRevision(OkTestCase):
 
         # Ensure that the backup is still accepted
         backups = Backup.query.filter_by(submitter=self.user5).count()
-        self.assertEquals(backups, 1)
+        self.assertEqual(backups, 1)
 
     def test_revison_test_group_member(self):
         self.login(self.user4.email)
@@ -109,7 +109,7 @@ class TestRevision(OkTestCase):
 
         group = self.assignment.active_user_ids(self.user4.id)
         revision = self.assignment.revision(group)
-        self.assertEquals(len(revision.owners()), 2)
+        self.assertEqual(len(revision.owners()), 2)
 
     def test_revison_multiple_submit(self):
         group = self.assignment.active_user_ids(self.user3.id)
@@ -127,8 +127,8 @@ class TestRevision(OkTestCase):
 
         second_revision = self.assignment.revision(group)
         self.assertTrue(second_revision.is_revision)
-        self.assertNotEquals(first_revision.id, second_revision.id)
+        self.assertNotEqual(first_revision.id, second_revision.id)
 
         # Check the number of revisions scores is 1
         scores = Score.query.filter_by(kind="revision", archived=False).count()
-        self.assertEquals(scores, 1)
+        self.assertEqual(scores, 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,39 +21,39 @@ class TestUtils(OkTestCase):
         five_chunks = utils.chunks(range(55), 5)
         five_chunks = utils.chunks(list(range(55)), 5)
 
-        self.assertEquals(list(three_chunks),
+        self.assertEqual(list(three_chunks),
                           [range(0, 19), range(19, 38), range(38, 56)])
-        self.assertEquals([len(i) for i in five_chunks],
+        self.assertEqual([len(i) for i in five_chunks],
                           [11, 11, 11, 11, 11])
-        self.assertEquals([], list(utils.chunks(list(range(21)), 0)))
+        self.assertEqual([], list(utils.chunks(list(range(21)), 0)))
 
-        self.assertEquals([len(x) for x in utils.chunks(range(45), 13)],
+        self.assertEqual([len(x) for x in utils.chunks(range(45), 13)],
                           [4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 3])
-        self.assertEquals([len(x) for x in utils.chunks(range(253), 13)],
+        self.assertEqual([len(x) for x in utils.chunks(range(253), 13)],
                           [20, 19, 20, 19, 20, 19, 20, 19, 20, 19, 20, 19, 19])
-        self.assertEquals([len(x) for x in utils.chunks(range(960), 48)], [20] * 48)
+        self.assertEqual([len(x) for x in utils.chunks(range(960), 48)], [20] * 48)
 
     def test_time(self):
         self.setup_course()
         # UTC Time
         time = dt.datetime(month=1, day=20, year=2016, hour=12, minute=1)
-        self.assertEquals(utils.local_time(time, self.course), 'Wed 01/20 04:01 AM')
+        self.assertEqual(utils.local_time(time, self.course), 'Wed 01/20 04:01 AM')
 
         # DT Aware
         pacific = pytz.timezone('US/Pacific')
         localized = pacific.localize(time)
-        self.assertEquals(utils.local_time(localized, self.course), 'Wed 01/20 12:01 PM')
+        self.assertEqual(utils.local_time(localized, self.course), 'Wed 01/20 12:01 PM')
 
         eastern = pytz.timezone('US/Eastern')
         localized = eastern.localize(time)
-        self.assertEquals(utils.local_time(localized, self.course), 'Wed 01/20 09:01 AM')
+        self.assertEqual(utils.local_time(localized, self.course), 'Wed 01/20 09:01 AM')
 
     def test_generate_number_table(self):
         results = {i: utils.generate_number_table(i) for i in range(1, 4)}
 
-        self.assertEquals(results[1], "SELECT 1 as pos")
-        self.assertEquals(results[2], "SELECT 1 as pos UNION SELECT 2 as pos")
-        self.assertEquals(results[3], "SELECT 1 as pos UNION SELECT 2 as pos UNION SELECT 3 as pos")
+        self.assertEqual(results[1], "SELECT 1 as pos")
+        self.assertEqual(results[2], "SELECT 1 as pos UNION SELECT 2 as pos")
+        self.assertEqual(results[3], "SELECT 1 as pos UNION SELECT 2 as pos UNION SELECT 3 as pos")
 
     def test_humanize_name(self):
         test_corpus = (
@@ -73,15 +73,15 @@ class TestUtils(OkTestCase):
                 ("Park-Guo, Byung-Woo", "Byung-Woo Park-Guo"),
                 ("Russell Diane Benjamin Lawrence, James", "James Russell Diane Benjamin Lawrence"),
                 )
-        self.assertEquals(utils.humanize_name(None), None)
+        self.assertEqual(utils.humanize_name(None), None)
         for name, expected in test_corpus:
-            self.assertEquals(utils.humanize_name(expected), expected)
-            self.assertEquals(utils.humanize_name(expected.upper()), expected)
-            self.assertEquals(utils.humanize_name(name), expected)
-            self.assertEquals(utils.humanize_name(name.upper()), expected)
-        self.assertEquals(utils.humanize_name("ronald mcdonald"), "ronald mcdonald")
-        self.assertEquals(utils.humanize_name("mcdonald, ronald"), "ronald mcdonald")
-        self.assertEquals(utils.humanize_name("ronald mcDonald"), "ronald mcDonald")
-        self.assertEquals(utils.humanize_name("mcDonald, ronald"), "ronald mcDonald")
-        self.assertEquals(utils.humanize_name("Ronald McDonald"), "Ronald McDonald")
-        self.assertEquals(utils.humanize_name("McDonald, Ronald"), "Ronald McDonald")
+            self.assertEqual(utils.humanize_name(expected), expected)
+            self.assertEqual(utils.humanize_name(expected.upper()), expected)
+            self.assertEqual(utils.humanize_name(name), expected)
+            self.assertEqual(utils.humanize_name(name.upper()), expected)
+        self.assertEqual(utils.humanize_name("ronald mcdonald"), "ronald mcdonald")
+        self.assertEqual(utils.humanize_name("mcdonald, ronald"), "ronald mcdonald")
+        self.assertEqual(utils.humanize_name("ronald mcDonald"), "ronald mcDonald")
+        self.assertEqual(utils.humanize_name("mcDonald, ronald"), "ronald mcDonald")
+        self.assertEqual(utils.humanize_name("Ronald McDonald"), "Ronald McDonald")
+        self.assertEqual(utils.humanize_name("McDonald, Ronald"), "Ronald McDonald")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -156,7 +156,7 @@ if driver:
             # Youtube throws a console warning, because PhantomJS doesn't support HTML5 video.
             # This isn't actually an error.
             self.page_load(self.get_server_url(), 1)
-            self.assertEquals("OK", self.driver.title)
+            self.assertEqual("OK", self.driver.title)
             self.driver.find_element_by_id('testing-login').click()
             self.assertIn('Login', self.driver.title)
 
@@ -166,7 +166,7 @@ if driver:
             self.assertIn('Courses | Ok', self.driver.title)
 
             self.driver.find_element_by_id('logout').click()
-            self.assertEquals("OK", self.driver.title)
+            self.assertEqual("OK", self.driver.title)
 
         def test_student_view(self):
             self._seed_course()
@@ -467,11 +467,11 @@ if driver:
 
             # Access page while not logged in - should redirect to login
             self.page_load(target_url)
-            self.assertEquals(self.driver.current_url, login_url)
+            self.assertEqual(self.driver.current_url, login_url)
 
             # Login and redirect back to original page
             self.driver.find_element_by_id('admin').click()
-            self.assertEquals(self.driver.current_url, target_url)
+            self.assertEqual(self.driver.current_url, target_url)
 
         def _confirm_oauth(self):
             self.driver.find_element_by_id('confirm-button').click()
@@ -479,7 +479,7 @@ if driver:
             # Get code from redirect URI
             redirect_uri, query_string = self.driver.current_url.split('?')
             query = dict(urllib.parse.parse_qsl(query_string))
-            self.assertEquals(redirect_uri, self.oauth_client.redirect_uris[0])
+            self.assertEqual(redirect_uri, self.oauth_client.redirect_uris[0])
             self.assertIn('code', query)
 
             # Try exchanging code for token
@@ -491,7 +491,7 @@ if driver:
                 'redirect_uri': self.oauth_client.redirect_uris[0],
                 'grant_type': 'authorization_code',
             })
-            self.assertEquals(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
             data = response.json()
             self.assertIn('access_token', data)
             self.assertIn('refresh_token', data)
@@ -529,7 +529,7 @@ if driver:
                 }),
             ))
             login_url = '{}/testing-login/'.format(self.get_server_url())
-            self.assertEquals(self.driver.current_url, login_url)
+            self.assertEqual(self.driver.current_url, login_url)
 
             # Login and redirect back to original page
             input_element = self.driver.find_element_by_id("email-login")
@@ -560,7 +560,7 @@ if driver:
             self.driver.find_element_by_id('reauthenticate-button').click()
 
             login_url = '{}/testing-login/'.format(self.get_server_url())
-            self.assertEquals(self.driver.current_url, login_url)
+            self.assertEqual(self.driver.current_url, login_url)
 
             # Login and redirect back to original page
             input_element = self.driver.find_element_by_id("email-login")


### PR DESCRIPTION
Running the tests via `python -m unittest` shows several warnings which this commit fixes:

- Remove use of deprecated `assertEquals` and `assertNotEquals` methods in favor of `assertEqual` and `assertNotEqual`.

- Remove unclosed file objects in setup method and avoid relying on platform default file encoding.

Note that there are still several other warnings, but those are emitted by libraries (e.g. deprecation warnings in werkzeug).

![Screenshot of unittest warnings](https://user-images.githubusercontent.com/1086421/39712358-b3095792-51f0-11e8-91ee-ed8be02ba62d.png)
