### PR TITLE
Make pip install during build more reliable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
     - USE_DOCKER=1
     - USE_NATIVE=1
 install:
-  - if [ -n "$USE_DOCKER" ]; then make docker-build; fi
-  - if [ -n "$USE_NATIVE" ]; then pip install -r requirements.txt; fi
-  - if [ -n "$USE_NATIVE" ]; then pip install pytest-timeout python-coveralls; fi
+  - if [ -n "$USE_DOCKER" ]; then travis_retry make docker-build; fi
+  - if [ -n "$USE_NATIVE" ]; then travis_retry pip --timeout=60 install -r requirements.txt; fi
+  - if [ -n "$USE_NATIVE" ]; then travis_retry pip --timeout=60 install pytest-timeout python-coveralls; fi
 script:
   - if [ -n "$USE_DOCKER" ]; then make docker-test; fi
   - if [ -n "$USE_NATIVE" ]; then py.test --cov-report term-missing --cov=server tests/  --ignore tests/test_web.py --timeout=30; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /code/
 WORKDIR /code/
 
 ADD requirements.txt .
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 --timeout=60 install --no-cache-dir -r requirements.txt
 
 ADD . .
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ env:
 	make deps
 
 deps:
-	pip install -r requirements.txt
+	pip --timeout=60 install -r requirements.txt
 
 clean:
 	./manage.py clean


### PR DESCRIPTION
We've been seeing a number of false-positive build breaks due to network issues when connecting to PyPI. Sample build: https://travis-ci.org/Cal-CS-61A-Staff/ok/jobs/375933342.

The recommended way to fix these issues is via retries in Travis, as per https://docs.travis-ci.com/user/common-build-problems/. Additionally, this change also increases the pip install timeout.