### PR TITLE
Add Support for Redis connection URLs

### DIFF
--- a/documentation/SETUP.md
+++ b/documentation/SETUP.md
@@ -26,7 +26,7 @@ Run tests via
 
     $ ./manage.py test
 
-In order to run the tests in `tests/test_web.py`, `phantom.js` needs to be installed. 
+In order to run the tests in `tests/test_web.py`, `phantom.js` needs to be installed.
 On OSX: First make sure [Homebrew](http://brew.sh/) is installed. To install `phantom.js`:
 
     $ brew install phantomjs
@@ -91,3 +91,46 @@ terminal run
 The command that Travis uses is
 
     $ make docker-test
+
+## Setting up Redis
+
+There are two ways to configure Redis:
+
+1. Connect to Redis using a URL
+2. Connect to Redis using socket connection details
+
+### Option 1: Connect to Redis using a URL
+
+By setting the `REDIS_URL` environment variable the server will attempt to connect to a Redis service using a URL in one of the following formats:
+
+```
+redis://[username:password]@[server]:[port]/[db]
+rediss://[username:password]@[server]:[port]/[db]
+```
+
+The `redis://` scheme connects to redis over a non-SSL connection, where as the `rediss://` scheme will use SSL.
+
+An example connection URL might look like this:
+
+`rediss://:reallystrongpassword=@myazureredisinstance.redis.cache.example.net:6380/0`
+
+Notes on this example:
+
+- This example omits a username. If you omit the username make sure still include the `:` which would normally separate username and password
+- This fictional Redis instance is at `myazureredisinstance.redis.cache.example.net`
+- Port `6380` is being used. For a non-secure endpoint, port `6379` would be appropriate
+- the `/O` at the end signifies database 0.
+
+For more information on the format of these URLs see the following:
+
+- `redis://` <http://www.iana.org/assignments/uri-schemes/prov/redis>
+- `rediss://` <http://www.iana.org/assignments/uri-schemes/prov/rediss>
+
+### Option 2: Connect using Host/Port details
+
+If the absense of the `REDIS_URL` environment variable, the server will look for the following environent variables and will use certain defaults if they're not found:
+
+Env Variable | Default Value | Purpose
+---|---|---
+`REDIS_HOST`|`localhost` for all non-prod environments<br> `redis-master` for prod|Redis host name
+`REDIS_PORT`|6379|Redis port

--- a/documentation/SETUP.md
+++ b/documentation/SETUP.md
@@ -112,11 +112,12 @@ The `redis://` scheme connects to redis over a non-SSL connection, where as the 
 
 An example connection URL might look like this:
 
-`rediss://:reallystrongpassword=@myazureredisinstance.redis.cache.example.net:6380/0`
+`rediss://:reallystrongpassword@myazureredisinstance.redis.cache.example.net:6380/0`
 
 Notes on this example:
 
 - This example omits a username. If you omit the username make sure still include the `:` which would normally separate username and password
+- The password for this Redis server is `reallystrongpassword`
 - This fictional Redis instance is at `myazureredisinstance.redis.cache.example.net`
 - Port `6380` is being used. For a non-secure endpoint, port `6379` would be appropriate
 - the `/O` at the end signifies database 0.

--- a/server/settings/_base.py
+++ b/server/settings/_base.py
@@ -11,18 +11,13 @@ def initialize_config(cls):
 
 class Config(object):
     SECRET_KEY = os.getenv('SECRET_KEY')
-    
+
     DEBUG = False
     ASSETS_DEBUG = False
     TESTING_LOGIN = False
     DEBUG_TB_INTERCEPT_REDIRECTS = False
-    
-    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
-    REDIS_PORT = 6379
-    RQ_POLL_INTERVAL = 2000
-    RQ_DEFAULT_HOST = REDIS_HOST = \
-        os.getenv('REDIS_HOST', 'localhost')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     STORAGE_SERVER = False
     STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'LOCAL')
@@ -34,6 +29,9 @@ class Config(object):
 
     @classmethod
     def initialize_config(cls):
+
+        cls.configure_redis()
+
         db_url = os.getenv('DATABASE_URL')
         if db_url:
             if 'mysql' in db_url:
@@ -74,3 +72,41 @@ class Config(object):
     @classmethod
     def verify_oauth_credentials(cls):
         raise NotImplementedError
+
+    @classmethod
+    def configure_redis(cls):
+        ''' Configures Redis by inspecting the environment
+        and setting Config properties'''
+
+        # use REDIS_URL in preference to other Redis configuration
+        redis_url = os.getenv('REDIS_URL')
+        if redis_url:
+            cls.REDIS_URL = redis_url
+            cls.RQ_DEFAULT_URL = redis_url
+            if cls.get_flask_caching_enabled():
+                cls.CACHE_REDIS_URL = redis_url
+
+        else:
+            cls.REDIS_PORT = int(os.getenv('REDIS_PORT', "6379"))
+            cls.REDIS_HOST = os.getenv('REDIS_HOST', cls.get_default_redis_host())
+
+            # setup Redis config for RQ
+            cls.RQ_DEFAULT_HOST = cls.REDIS_HOST
+
+            # setup Redis config for Flash-Cache
+            if cls.get_flask_caching_enabled():
+                cls.CACHE_REDIS_HOST = cls.REDIS_HOST
+
+        cls.RQ_POLL_INTERVAL = 2000
+
+    @classmethod
+    def get_default_redis_host(cls):
+        ''' Returns the default Redis host.
+        Overridden in specific environment settings'''
+        return 'localhost'
+
+    @classmethod
+    def get_flask_caching_enabled(cls):
+        ''' Returns True if flask caching should be enabled
+        Overridden in specific environment settings'''
+        return False

--- a/server/settings/_prodbase.py
+++ b/server/settings/_prodbase.py
@@ -11,11 +11,8 @@ class Config(object):
 
     WTF_CSRF_CHECK_DEFAULT = True
     WTF_CSRF_ENABLED = True
-    
-    CACHE_TYPE = 'simple'
 
-    RQ_DEFAULT_HOST = REDIS_HOST = CACHE_REDIS_HOST = \
-        os.getenv('REDIS_HOST', 'redis-master')
+    CACHE_TYPE = 'simple'
 
     STORAGE_CONTAINER = os.environ.get('STORAGE_CONTAINER',  'ok-v3-user-files')
 

--- a/server/settings/prod.py
+++ b/server/settings/prod.py
@@ -18,7 +18,7 @@ class Config(ProdBaseConfig, BaseConfig):
     CACHE_TYPE = 'redis'
     CACHE_KEY_PREFIX = 'ok-web'
 
-    # The Google Cloud load balancer behaves like two proxies: 
+    # The Google Cloud load balancer behaves like two proxies:
     # one with the external fowarding rule IP, and
     # one with an internal IP.
     # See https://cloud.google.com/compute/docs/load-balancing/http/#target_proxies
@@ -29,3 +29,11 @@ class Config(ProdBaseConfig, BaseConfig):
     def get_default_db_url(cls):
         print("The database URL is not set!")
         sys.exit(1)
+
+    @classmethod
+    def get_default_redis_host(cls):
+        return 'redis-master'
+
+    @classmethod
+    def get_flask_caching_enabled(cls):
+        return True


### PR DESCRIPTION
This pull request adds support for Redis connection URLs such as...

`rediss://:reallystrongpassword@myazureredisinstance.redis.cache.example.net:6380/0`

This change allows you to configure Redis with a single environment variable, but more importantly it allows secure SSL connections, that are then used by Flask-Cache and RQ, through support of the `rediss://` url scheme.

(for more details, see <https://www.iana.org/assignments/uri-schemes/prov/rediss>)

The changes are relatively simple. The Redis configuration has been refactored, and uses the environment variable `REDIS_URL` if present. Otherwise everything works as it always did with the only change being that `REDIS_PORT` is now a configuration item.

I've pulled almost all of the Redis configuration up into `_base.py` and then use overrides in `prod.py`.

I've also updated the SETUP.md documentation to include a section on configuring Redis. I'm happy to make this clearer if needed.