### PR TITLE
Fixing the issue where OAUTH_PROVIDER is not being set properly

### DIFF
--- a/server/settings/_base.py
+++ b/server/settings/_base.py
@@ -98,8 +98,6 @@ class Config(object):
         if cls.STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(cls.STORAGE_CONTAINER):
             os.makedirs(cls.STORAGE_CONTAINER)
 
-        cls.verify_oauth_credentials()
-
 
     @classmethod
     def get_default_db_url(cls):

--- a/server/settings/_prodbase.py
+++ b/server/settings/_prodbase.py
@@ -24,12 +24,10 @@ class Config(object):
         'key': os.environ.get("SENDGRID_KEY")
     }
 
-    @classmethod
-    def verify_oauth_credentials(cls):
-        if "GOOGLE_ID" in os.environ or "GOOGLE_SECRET" in os.environ:
-            OAUTH_PROVIDER = 'GOOGLE'
-        elif "MICROSOFT_APP_ID" in os.environ or "MICROSOFT_APP_SECRET" in os.environ:
-            OAUTH_PROVIDER = 'MICROSOFT'
-        else:
-            print("Please set the Google or Microsoft OAuth ID and Secret variables.")
-            sys.exit(1)
+    if "GOOGLE_ID" in os.environ or "GOOGLE_SECRET" in os.environ:
+        OAUTH_PROVIDER = 'GOOGLE'
+    elif "MICROSOFT_APP_ID" in os.environ or "MICROSOFT_APP_SECRET" in os.environ:
+        OAUTH_PROVIDER = 'MICROSOFT'
+    else:
+        print("Please set the Google or Microsoft OAuth ID and Secret variables.")
+        sys.exit(1)


### PR DESCRIPTION
Fixing the issue where OAUTH_PROVIDER was always set to 'GOOGLE' (the default value) because the config variable was not being properly setup.