### PR TITLE
Switch to pessimistic SQL disconnect handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,7 @@
 *.pydevproject
 *.kpf
 *.iml
-venv
+venv*
 env
 .env
 *.tags*

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.pydevproject
 *.kpf
 *.iml
-venv
+venv*
 env
 .env
 *.tags*

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ raven[flask]==6.0.0
 
 # Database
 pymysql==0.8.0
-sqlalchemy==1.1.9
+sqlalchemy==1.2.8
 
 # Caching
 redis==2.10.5

--- a/server/settings/_base.py
+++ b/server/settings/_base.py
@@ -89,8 +89,7 @@ class Config(object):
 
         sql_ca_cert = os.getenv('SQL_CA_CERT', os.path.abspath('./BaltimoreCyberTrustRoot.crt.pem'))
         if sql_ca_cert and 'azure' in cls.SQLALCHEMY_DATABASE_URI:
-            cls.SQLALCHEMY_ENGINE_OPTS = {'connect_args': {'ssl': {'ca': sql_ca_cert}}}
-            cls.SQLALCHEMY_POOL_RECYCLE = 25 * 60  # Restart connections before 25 minutes Azure timeout
+            cls.SQLALCHEMY_ENGINE_OPTS = {'connect_args': {'ssl': {'ca': sql_ca_cert}}, 'pool_pre_ping': True}
 
         if cls.STORAGE_PROVIDER == 'LOCAL' and not os.path.exists(cls.STORAGE_CONTAINER):
             os.makedirs(cls.STORAGE_CONTAINER)


### PR DESCRIPTION
Previously we were using optimistic disconnect handling for the database connection pool: assume that all the connections are live and recycle them before a certain timeout just in case the server kills the connections after a certain period of inactivity. This approach reduced the frequency of "MySQL went away" errors, but it turns out that it didn't eliminate them.

As such, this change switches to pessimistic disconnect handling: before using a given connection, it is first tested for liveness by SQLAlchemy. This is implemented by passing `pool_pre_ping` to the `create_engine` call ([docs](http://docs.sqlalchemy.org/en/latest/core/pooling.html#pool-disconnects-pessimistic)). Note that this option was only introduced in SQLAlchemy 1.2 ([announcement](https://twitter.com/sqlalchemy/status/884415051125452802)) so this change also updates the SQLAlchemy dependency to the latest release.
