### PR TITLE
Parameterize autograder URL

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -1,4 +1,5 @@
 """App constants"""
+import os
 
 STUDENT_ROLE = 'student'
 GRADER_ROLE = 'grader'
@@ -33,7 +34,7 @@ GRADES_BUCKET = 'ok_grades_bucket'
 TIMEZONE = 'America/Los_Angeles'
 ISO_DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
 
-AUTOGRADER_URL = 'https://autograder.cs61a.org'
+AUTOGRADER_URL = os.getenv('AUTOGRADER_URL', 'https://autograder.cs61a.org')
 
 FORBIDDEN_ROUTE_NAMES = [
     'about',


### PR DESCRIPTION
Enabling the `AUTOGRADER_URL` value to be set by deployments of the application means that we don't have to rely on a single autograder deployment and other OK users such as Imperial College can deploy their own instances.

Note that it's a bit of a misnomer to have the `AUTOGRADER_URL` in the constants file but dereference it from an environment variable. Likely a more consistent place would be the Flask app settings. However, the autograder is implemented outside of the Flask app context so it might be a non-trivial change to pull the configuration from the Flask settings and it would unnecessarily couple the two. As such, reading the environment variable in the constants file seems like a pragmatic compromise.