### PR TITLE
Fix link to ARM template

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -61,5 +61,5 @@ The [Azure Application Insights](https://azure.microsoft.com/en-gb/services/appl
 monitoring can be enabled by setting the following environment variables:
 
 ```
-APPLICATION_INSIGHTS_KEY={InstrumentationKey}
+APPINSIGHTS_INSTRUMENTATIONKEY={InstrumentationKey}
 ```

--- a/azure/paas/README.md
+++ b/azure/paas/README.md
@@ -22,6 +22,6 @@ If you do not have access to PowerShell this can be run in the cloud shell via t
 
 To deploy [Ok.py](www.okpy.org) to Azure use the deploy button below. If you are not familiar with the configuration of Azure resources please check our [integration guide](../).
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Ficokpy%2Fok%2Fenhancement%2Ficokpy%2Fazure-templates%2Fazure%2Fpaas%2Fazure.deploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FCal-CS-61A-Staff%2Fok%2Fmaster%2Fazure%2Fpaas%2Fazure.deploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>

--- a/azure/paas/azure.deploy.json
+++ b/azure/paas/azure.deploy.json
@@ -457,7 +457,7 @@
             "value": "[variables('mySQLServerName')]"
           },
           "redisURL": {
-            "value": "[concat('rediss://:',reference('redis').outputs.rediskey.value,'@',reference('redis').outputs.redis.value.hostName,'6380','/0')]"
+            "value": "[concat('rediss://:',reference('redis').outputs.rediskey.value,'@',reference('redis').outputs.redis.value.hostName,':6380','/0')]"
           },
           "sendgridAccountName": {
             "value": "[reference('SendGrid').outputs.SendGrid.value.username]"

--- a/azure/paas/azure.deploy.json
+++ b/azure/paas/azure.deploy.json
@@ -105,7 +105,7 @@
     },
     "templateBaseURL": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/icokpy/ok/enhancement/icokpy/azure-templates/azure/paas/",
+      "defaultValue": "https://raw.githubusercontent.com/Cal-CS-61A-Staff/ok/master/azure/paas/",
       "metadata": {
         "description": "Repo base URL"
       }

--- a/azure/paas/webapp.deploy.json
+++ b/azure/paas/webapp.deploy.json
@@ -181,7 +181,7 @@
             "SENDGRID_USER": "[parameters('sendgridAccountName')]",
             "SENDGRID_KEY": "[parameters('sendgridPassword')]",
             "WEBSITE_HTTPLOGGING_RETENTION_DAYS": "7",
-            "APPLICATION_INSIGHTS_KEY": "[parameters('applicationInsightsKey')]",
+            "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('applicationInsightsKey')]",
             "MICROSOFT_APP_SECRET": "[parameters('azureAdAppSecret')]",
             "MICROSOFT_APP_ID": "[parameters('azureAdAppId')]",
             "MICROSOFT_TENANT_ID": "[parameters('azureAdTenantId')]",


### PR DESCRIPTION
For some reason the ARM template link in the "Deploy to Azure" button and templateBaseURL were still pointing to development fork and branch. This pull request updates the ARM template links to point to the canonical upstream repository and master branch.

Also:
- Fix a typo in the ARM template's setup of the Redis connection URI for the OKpy worker.
- Fix the name of the AppInsights environment variable set in the ARM template.