### PR TITLE
Protect against set but empty OAuth variables

### DIFF
--- a/server/settings/_prodbase.py
+++ b/server/settings/_prodbase.py
@@ -24,9 +24,9 @@ class Config(object):
         'key': os.environ.get("SENDGRID_KEY")
     }
 
-    if "GOOGLE_ID" in os.environ or "GOOGLE_SECRET" in os.environ:
+    if os.environ.get("GOOGLE_ID") and os.environ.get("GOOGLE_SECRET"):
         OAUTH_PROVIDER = 'GOOGLE'
-    elif "MICROSOFT_APP_ID" in os.environ or "MICROSOFT_APP_SECRET" in os.environ:
+    elif os.environ.get("MICROSOFT_APP_ID") and os.environ.get("MICROSOFT_APP_SECRET"):
         OAUTH_PROVIDER = 'MICROSOFT'
     else:
         print("Please set the Google or Microsoft OAuth ID and Secret variables.")


### PR DESCRIPTION
Currently we're only checking whether the variables like `GOOGLE_ID` or `MICROSOFT_APP_SECRET` are set as environment variables but we aren't validating whether the variables are non-empty. This means that the
server start might be successful but we'll fail later at login time which is harder to debug. This change fixes that behavior and prevents server start if the OAuth variables are set but contain empty values.