### PR TITLE
Parameterize all uses of the autograder URL

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -25,7 +25,7 @@ from server.models import (User, Course, Assignment, Enrollment, Version,
 from server.contrib import analyze
 
 from server.constants import (EMAIL_FORMAT, INSTRUCTOR_ROLE, STAFF_ROLES, STUDENT_ROLE,
-                              LAB_ASSISTANT_ROLE, SCORE_KINDS)
+                              LAB_ASSISTANT_ROLE, SCORE_KINDS, AUTOGRADER_URL)
 import server.canvas.api as canvas_api
 import server.canvas.jobs
 from server.extensions import cache
@@ -552,7 +552,7 @@ def assignment(cid, aid):
         flash("Assignment edited successfully.", "success")
 
     return render_template('staff/course/assignment/assignment.html', assignment=assign,
-                           form=form, courses=courses,
+                           form=form, courses=courses, autograder_url=AUTOGRADER_URL,
                            current_course=current_course)
 
 @admin.route("/course/<int:cid>/assignments/<int:aid>/stats")
@@ -684,8 +684,8 @@ def view_scores(cid, aid):
 
         bar_charts[kind] = bar_chart.render().decode("utf-8")
 
-
     return render_template('staff/course/assignment/assignment.scores.html',
+                           autograder_url=AUTOGRADER_URL,
                            assignment=assign, current_course=current_course,
                            courses=courses, scores=all_scores,
                            score_plots=bar_charts)

--- a/server/templates/staff/course/assignment/assignment.html
+++ b/server/templates/staff/course/assignment/assignment.html
@@ -95,7 +95,7 @@
                   <li> <a href="{{ url_for('.effort_grading', cid=current_course.id, aid=assignment.id) }}" type="button">
                         <i class="fa fa-thumbs-up"></i> Effort Grading
                   </a></li>
-                  <li> <a href="http://autograder.cs61a.org" target="_blank" type="button">
+                  <li> <a href="{{ autograder_url }}" target="_blank" type="button">
                         <i class="fa fa-gear"></i> Configure Autograder
                   </a></li>
                   <li>

--- a/server/templates/staff/course/assignment/assignment.scores.html
+++ b/server/templates/staff/course/assignment/assignment.scores.html
@@ -77,7 +77,7 @@
                         </button>
                     {% endcall %}
                   </li>
-                  <li> <a href="http://autograder.cs61a.org" target="_blank" type="button">
+                  <li> <a href="{{ autograder_url }}" target="_blank" type="button">
                         <i class="fa fa-gear"></i> Go To Autograder
                   </a></li>
                   <li> <a href="{{ url_for('.publish_scores', cid=current_course.id, aid=assignment.id) }}" type="button">


### PR DESCRIPTION
This issue was found and reported by @taupalosaurus: the autograder URL can now be over-written with an environment variable so all places where the URL is used should reflect that.
