### PR TITLE
Turn on "AlwaysOn" AppService option

### DIFF
--- a/azure/paas/webapp.deploy.json
+++ b/azure/paas/webapp.deploy.json
@@ -150,7 +150,10 @@
         "name": "[parameters('appName')]",
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms',concat(parameters('appName'),'_plan'))]",
         "httpLoggingEnabled": true,
-        "logsDirectorySizeLimit": 35
+        "logsDirectorySizeLimit": 35,
+        "siteConfig": {
+          "AlwaysOn": true
+        }
       },
       "resources": [
         {


### PR DESCRIPTION
By default, AppService will unload applications when there's no load to save money and reload them when there's traffic. This works reasonably well for websites but not for background workers which get triggered not by HTTP requests but by external code-specific triggers such as a Redis queue notification.

More information: https://docs.microsoft.com/en-us/azure/app-service/web-sites-configure