### PR TITLE
Add sendgrid username/password authentication

### DIFF
--- a/azure/paas/azure.deploy.json
+++ b/azure/paas/azure.deploy.json
@@ -374,7 +374,7 @@
           "redisURL": {
             "value": "[concat('rediss://:',reference('redis').outputs.rediskey.value,'@',reference('redis').outputs.redis.value.hostName,':6380','/0')]"
           },
-          "sendgridAccountName": {
+          "sendgridUserName": {
             "value": "[reference('SendGrid').outputs.SendGrid.value.username]"
           },
           "sendgridPassword": {
@@ -459,7 +459,7 @@
           "redisURL": {
             "value": "[concat('rediss://:',reference('redis').outputs.rediskey.value,'@',reference('redis').outputs.redis.value.hostName,':6380','/0')]"
           },
-          "sendgridAccountName": {
+          "sendgridUserName": {
             "value": "[reference('SendGrid').outputs.SendGrid.value.username]"
           },
           "sendgridPassword": {

--- a/azure/paas/webapp.deploy.json
+++ b/azure/paas/webapp.deploy.json
@@ -88,16 +88,16 @@
         "description": "redis URL"
       }
     },
-    "sendgridAccountName": {
+    "sendgridUserName": {
       "type": "string",
       "metadata": {
-        "description": "SendGrid Account Name"
+        "description": "SendGrid username"
       }
     },
     "sendgridPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "SendGrid  password"
+        "description": "SendGrid password"
       }
     },
     "applicationInsightsKey": {
@@ -181,8 +181,8 @@
             "STORAGE_SECRET": "[parameters('storageAccountKey')]",
             "STORAGE_CONTAINER": "okpyfiles",
             "OK_ENV": "[parameters('OkPyEnvironment')]",
-            "SENDGRID_USER": "[parameters('sendgridAccountName')]",
-            "SENDGRID_KEY": "[parameters('sendgridPassword')]",
+            "SENDGRID_USERNAME": "[parameters('sendgridUserName')]",
+            "SENDGRID_PASSWORD": "[parameters('sendgridPassword')]",
             "WEBSITE_HTTPLOGGING_RETENTION_DAYS": "7",
             "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('applicationInsightsKey')]",
             "MICROSOFT_APP_SECRET": "[parameters('azureAdAppSecret')]",

--- a/server/constants.py
+++ b/server/constants.py
@@ -36,6 +36,10 @@ ISO_DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
 
 AUTOGRADER_URL = os.getenv('AUTOGRADER_URL', 'https://autograder.cs61a.org')
 
+SENDGRID_USERNAME = os.getenv("SENDGRID_USERNAME")
+SENDGRID_PASSWORD = os.getenv("SENDGRID_PASSWORD")
+SENDGRID_KEY = os.getenv("SENDGRID_KEY")
+
 FORBIDDEN_ROUTE_NAMES = [
     'about',
     'admin',

--- a/server/settings/_prodbase.py
+++ b/server/settings/_prodbase.py
@@ -19,11 +19,6 @@ class Config(object):
 
     RAVEN_IGNORE_EXCEPTIONS = raven_exceptions
 
-    SENDGRID_AUTH = {
-        'user': os.environ.get("SENDGRID_USER"),
-        'key': os.environ.get("SENDGRID_KEY")
-    }
-
     if os.environ.get("GOOGLE_ID") and os.environ.get("GOOGLE_SECRET"):
         OAUTH_PROVIDER = 'GOOGLE'
     elif os.environ.get("MICROSOFT_APP_ID") and os.environ.get("MICROSOFT_APP_SECRET"):


### PR DESCRIPTION
This change fixes an issue where the Azure PaaS deployments were unable
to send mail via Sendgrid.

The issue was caused by the fact that the Sendgrid API assumes
authentication via an API key, but in the ARM template we only have
access to the Sendgrid account admin username and password. Due to the
limitations of the ARM template format, it's difficult to automatically
generate the API key outside of the OKpy application during the
deployment: we'd have to spin up an Azure Container Instances
deployment, generate the key in the container, upload it to a storage
like Key Vault and then access the key from the OKpy application.
Reading configuration from a storage like Key Vault instead of
environment variables would be a non-trivial change to OKpy so this
commit implements a more pragmatic work-around: generate a new API key
on the fly at runtime given the Sendgrid admin credentials. The key is
cached for the lifetime of the server so this shouldn't add overhead
past the first email sent.

Note that the Sendgrid API has a limit on 100 API keys so we always
ensure to auto-create at most one API key for OKpy and delete any old
copies of the key before creating a new one (this would happen when the
OKpy server is restarted since any auto-created API key only is
persisted in the server memory).

Another nice property of this change is that it's now possible to
authenticate to Sendgrid in OKpy in the same way as we do in AutoPY.